### PR TITLE
fix: remove broken local replace directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/HoangP8/tokless
 
 go 1.22
-
-replace empty-name => /home/hoangp/empty-name
-
-require empty-name v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Summary
- Remove `replace empty-name => /home/hoangp/empty-name` directive that points to a local path not available on other machines
- Remove `require empty-name` which is not imported anywhere in the codebase
- Makes the project buildable without local workarounds

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)