### PR TITLE
fix: correct plural() to use proper English pluralization

### DIFF
--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -31,7 +31,7 @@ func plural(n int) string {
 	if n == 1 {
 		return "1 tool"
 	}
-	return itoa(n) + " tool(s)"
+	return itoa(n) + " tools"
 }
 
 func itoa(n int) string {


### PR DESCRIPTION
## Summary
- Change `"N tool(s)"` to `"N tools"` in `plural()` function
- The parenthesized form reads awkwardly in user-facing CLI output
- Keeps `"1 tool"` for singular

## Test plan
- [ ] `go build ./...` succeeds
- [ ] Run `tokless doctor` with multiple tools — output says "2 tools" not "2 tool(s)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)