### PR TITLE
docs: add missing commands and flags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ irm https://raw.githubusercontent.com/HoangP8/tokless/main/scripts/install.ps1 |
 tokless              Install + wire everything (default; safe to re-run)
 tokless update       Show the version diff and upgrade the four tools
 tokless doctor       Show what's wired up; warn about anything broken
+tokless index        Build per-project indexes (codegraph) in the current dir
 tokless uninstall    Remove everything tokless ever touched
 tokless self-update  Update the tokless CLI itself
 ```
@@ -67,6 +68,7 @@ Flags:
 
 ```
 --agents <list>   Limit to a subset: claude,opencode,codex
+--tools <list>    Limit to a subset: rtk,caveman,codegraph,context-mode
 --dry-run         Show what would change without writing anything
 --verbose         Show every step
 ```


### PR DESCRIPTION
## Summary
- Add `index` command to README commands section (builds per-project codegraph indexes)
- Add `--tools <list>` flag documentation (limits to subset of tools)
- These were implemented and shown in `--help` output but missing from README

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Commands/flags match `tokless --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)