### PR TITLE
refactor: deduplicate toAnySlice/toAny helper functions

### DIFF
--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -29,7 +29,7 @@ func ConfigureClaudeMcp(toolID string) (changed bool, file string) {
 	desired := util.NewOrderedMap()
 	desired.Set("type", "stdio")
 	desired.Set("command", spawn.Command)
-	desired.Set("args", toAnySlice(spawn.Args))
+	desired.Set("args", util.ToAnySlice(spawn.Args))
 
 	if existing, ok := servers.Get(toolID); ok {
 		if claudeMcpEqual(existing, desired) {
@@ -133,14 +133,6 @@ func getOrCreateMap(m *util.OrderedMap, key string) *util.OrderedMap {
 	om := util.NewOrderedMap()
 	m.Set(key, om)
 	return om
-}
-
-func toAnySlice(ss []string) []any {
-	out := make([]any, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
 }
 
 func jsonStr(v any) string {

--- a/internal/agents/opencode.go
+++ b/internal/agents/opencode.go
@@ -28,7 +28,7 @@ func ConfigureOpenCodeMcp(toolID string) (changed bool, file string) {
 	command := append([]string{spawn.Command}, spawn.Args...)
 	desired := util.NewOrderedMap()
 	desired.Set("type", "local")
-	desired.Set("command", toAnySlice(command))
+	desired.Set("command", util.ToAnySlice(command))
 	desired.Set("enabled", true)
 
 	if existing, ok := mcp.Get(toolID); ok {

--- a/internal/tools/contextmode.go
+++ b/internal/tools/contextmode.go
@@ -55,7 +55,7 @@ func ctxWireClaude(opts core.RunOpts) (bool, error) {
 		entry := util.NewOrderedMap()
 		entry.Set("type", "stdio")
 		entry.Set("command", spawn.Command)
-		entry.Set("args", toAny(spawn.Args))
+		entry.Set("args", util.ToAnySlice(spawn.Args))
 		servers.Set("context-mode", entry)
 		_ = util.WriteFile(cp.GlobalJSON, util.StringifyJSON(cfg))
 		return true, nil
@@ -538,10 +538,3 @@ func getArr(m *util.OrderedMap, key string) []any {
 	return []any{}
 }
 
-func toAny(ss []string) []any {
-	out := make([]any, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
-}

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -143,3 +143,12 @@ func CodexPathsResolved() CodexPaths {
 		Instructions: filepath.Join(dir, "AGENTS.md"),
 	}
 }
+
+// ToAnySlice converts a string slice to an any slice.
+func ToAnySlice(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Consolidate identical `toAnySlice()` (agents/claude.go) and `toAny()` (tools/contextmode.go) into `util.ToAnySlice()`
- Both converted `[]string` to `[]any` with identical logic
- Single source of truth in util package

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `go test ./...` passes
- [ ] `tokless` init flow wires agents correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)