### PR TITLE
ci: add golangci-lint to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
       - name: Test
         run: go test ./...
 


### PR DESCRIPTION
## Summary
- Add `golangci-lint` step to CI workflow using official `golangci/golangci-lint-action@v6`
- `go vet` alone catches only a subset of issues; golangci-lint runs staticcheck, errcheck, unused, and more
- Runs on every push to main and every PR

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Lint step reports results correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)