### PR TITLE
refactor: consolidate duplicate getOrCreateMap helpers

### DIFF
--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -18,7 +18,7 @@ func ConfigureClaudeMcp(toolID string) (changed bool, file string) {
 	if cfg == nil {
 		cfg = util.NewOrderedMap()
 	}
-	servers := getOrCreateMap(cfg, "mcpServers")
+	servers := util.GetOrCreateMap(cfg, "mcpServers")
 
 	var spawn util.McpSpawn
 	if toolID == "codegraph" {
@@ -123,17 +123,6 @@ func detectAgent(cli, configDir string) core.Detection {
 }
 
 // shared helpers
-
-func getOrCreateMap(m *util.OrderedMap, key string) *util.OrderedMap {
-	if v, ok := m.Get(key); ok {
-		if om, ok := v.(*util.OrderedMap); ok {
-			return om
-		}
-	}
-	om := util.NewOrderedMap()
-	m.Set(key, om)
-	return om
-}
 
 func toAnySlice(ss []string) []any {
 	out := make([]any, len(ss))

--- a/internal/agents/opencode.go
+++ b/internal/agents/opencode.go
@@ -17,7 +17,7 @@ func ConfigureOpenCodeMcp(toolID string) (changed bool, file string) {
 	if _, ok := cfg.Get("$schema"); !ok {
 		cfg.Set("$schema", "https://opencode.ai/config.json")
 	}
-	mcp := getOrCreateMap(cfg, "mcp")
+	mcp := util.GetOrCreateMap(cfg, "mcp")
 
 	var spawn util.McpSpawn
 	if toolID == "codegraph" {

--- a/internal/tools/autoindex.go
+++ b/internal/tools/autoindex.go
@@ -15,7 +15,7 @@ func wireClaudeAutoIndex() {
 	cp := util.ClaudeCodePaths()
 	_ = util.EnsureDir(cp.Dir)
 	cfg := loadOrdered(cp.Settings)
-	hooks := getOrCreateMapT(cfg, "hooks")
+	hooks := util.GetOrCreateMap(cfg, "hooks")
 	if claudeHasAutoIndex(hooks) {
 		return
 	}
@@ -81,7 +81,7 @@ func wireCodexAutoIndex() {
 	_ = util.EnsureDir(cx.Dir)
 	hooksPath := filepath.Join(cx.Dir, "hooks.json")
 	cfg := loadOrdered(hooksPath)
-	hooks := getOrCreateMapT(cfg, "hooks")
+	hooks := util.GetOrCreateMap(cfg, "hooks")
 	var ss []any
 	if v, ok := hooks.Get("SessionStart"); ok {
 		if existing, ok := v.([]any); ok {

--- a/internal/tools/contextmode.go
+++ b/internal/tools/contextmode.go
@@ -51,7 +51,7 @@ func ctxWireClaude(opts core.RunOpts) (bool, error) {
 		cp := util.ClaudeCodePaths()
 		_ = util.EnsureDir(cp.Dir)
 		cfg := loadOrdered(cp.GlobalJSON)
-		servers := getOrCreateMapT(cfg, "mcpServers")
+		servers := util.GetOrCreateMap(cfg, "mcpServers")
 		entry := util.NewOrderedMap()
 		entry.Set("type", "stdio")
 		entry.Set("command", spawn.Command)
@@ -268,7 +268,7 @@ func mergeCodexHooks(existing *util.OrderedMap) *util.OrderedMap {
 	if out == nil {
 		out = util.NewOrderedMap()
 	}
-	hooks := getOrCreateMapT(out, "hooks")
+	hooks := util.GetOrCreateMap(out, "hooks")
 	for _, event := range codexHookEvents {
 		var arr []any
 		if v, ok := hooks.Get(event); ok {

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -13,17 +13,6 @@ func writeIfMissing(path, content string) {
 	}
 }
 
-func getOrCreateMapT(m *util.OrderedMap, key string) *util.OrderedMap {
-	if v, ok := m.Get(key); ok {
-		if om, ok := v.(*util.OrderedMap); ok {
-			return om
-		}
-	}
-	om := util.NewOrderedMap()
-	m.Set(key, om)
-	return om
-}
-
 // clip trims and caps stderr for log lines (mirrors .slice(0,200)).
 func clip(s string) string {
 	s = strings.TrimSpace(s)

--- a/internal/tools/rtk.go
+++ b/internal/tools/rtk.go
@@ -127,7 +127,7 @@ func rtkTestShim(agent string) {
 					cfg = m
 				}
 			}
-			hooks := getOrCreateMapT(cfg, "hooks")
+			hooks := util.GetOrCreateMap(cfg, "hooks")
 			var pre []any
 			if v, ok := hooks.Get("PreToolUse"); ok {
 				if arr, ok := v.([]any); ok {

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -143,3 +143,15 @@ func CodexPathsResolved() CodexPaths {
 		Instructions: filepath.Join(dir, "AGENTS.md"),
 	}
 }
+
+// GetOrCreateMap returns the OrderedMap at key, creating one if absent.
+func GetOrCreateMap(m *OrderedMap, key string) *OrderedMap {
+	if v, ok := m.Get(key); ok {
+		if om, ok := v.(*OrderedMap); ok {
+			return om
+		}
+	}
+	om := NewOrderedMap()
+	m.Set(key, om)
+	return om
+}


### PR DESCRIPTION
## Summary
- Consolidate identical `getOrCreateMap()` (agents/claude.go) and `getOrCreateMapT()` (tools/helpers.go) into `util.GetOrCreateMap()`
- Both created-or-returned an OrderedMap sub-key with identical logic
- Updates all call sites in agents and tools packages

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `go test ./...` passes
- [ ] `tokless` init + doctor work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)