### PR TITLE
feat: add tokless info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Each tool is wired into each agent through the agent's native config system:
 tokless              Install + wire everything (default; safe to re-run)
 tokless update       Show version diff and upgrade tools
 tokless doctor       Show what's wired; warn about broken bits
+tokless info         Show how tokless was installed, plus paths and config locations
 tokless index        Build per-project codegraph indexes
 tokless disable      Disable one or more agents
 tokless uninstall    Remove everything tokless touched

--- a/cmd/tokless/main.go
+++ b/cmd/tokless/main.go
@@ -48,6 +48,7 @@ func helpText() string {
 		"  " + cy("tokless") + "              Install + wire everything (default; safe to re-run)\n" +
 		"  " + cy("tokless update") + "       Show version diff and upgrade tools\n" +
 		"  " + cy("tokless doctor") + "       Show what's wired up; warn about anything broken\n" +
+		"  " + cy("tokless info") + "         Show how tokless was installed, plus paths and config locations\n" +
 		"  " + cy("tokless index") + "        Build per-project indexes (codegraph) in the current dir\n" +
 		"  " + cy("tokless uninstall") + "    Remove everything tokless ever touched\n\n" +
 		util.C.Bold("Flags:") + "\n" +
@@ -172,6 +173,8 @@ func run() int {
 		code = commands.RunUpdate(opts)
 	case "doctor":
 		code = commands.RunDoctor(p.bools["offline"])
+	case "info":
+		code = commands.RunInfo()
 	case "index":
 		code = commands.RunIndex(opts, p.bools["auto"])
 	case "disable":

--- a/internal/commands/disable.go
+++ b/internal/commands/disable.go
@@ -124,6 +124,7 @@ func disableImpl(opts InitOptions, removeTools bool, verb string) int {
 		if util.Exists(cacheDir) {
 			_ = os.RemoveAll(cacheDir)
 		}
+		_ = os.Remove(util.InstallMarkerPath())
 	}
 
 	labels := make([]string, len(agentIDs))

--- a/internal/commands/info.go
+++ b/internal/commands/info.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/HoangP8/tokless/internal/core"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+// RunInfo prints where tokless came from and where everything lives.
+// It is deliberately offline: health and update checks belong to doctor.
+func RunInfo() int {
+	util.L.Raw("")
+	util.L.Raw("  " + util.C.Bold(util.C.Cyan("tokless info")) + util.C.Gray("  install + paths"))
+	util.L.Raw("")
+
+	rec, exact := util.InstallInfo()
+	install := rec.Method
+	if !exact {
+		install += util.C.Gray(" (guessed from path)")
+	} else if rec.At != "" {
+		install += util.C.Gray("  " + firstField(rec.At, "T"))
+	}
+
+	infoRow("version", util.ToklessVersion())
+	infoRow("binary", tildePath(util.ToklessAbs()))
+	infoRow("install", install)
+
+	util.L.Raw("")
+	util.L.Raw("  " + util.C.Bold("Agents"))
+	for _, agent := range core.ListAgents() {
+		dir := ""
+		if agent.ConfigDir != nil {
+			dir = tildePath(agent.ConfigDir())
+		}
+		if !agent.Detect().Installed {
+			util.L.Raw("  " + util.C.Gray(util.Sym.Bullet+" "+padEnd(agent.Label, 16)+"not installed"))
+			continue
+		}
+		if dir == "" {
+			dir = util.C.Gray("—")
+		}
+		util.L.Raw("  " + util.C.Green(util.Sym.Check) + " " + padEnd(agent.Label, 16) + util.C.Gray(dir))
+	}
+
+	util.L.Raw("")
+	util.L.Raw("  " + util.C.Bold("Tools"))
+	for _, tool := range core.ListTools() {
+		if tool.InstructionOnly {
+			continue
+		}
+		if v := util.InstalledVersionFor(tool.ID); v != nil {
+			row := padEnd(tool.ID, 16) + padEnd("v"+*v, 12)
+			if p := util.InstalledPathFor(tool.ID); p != "" {
+				row += tildePath(p)
+			}
+			util.L.Raw("  " + util.C.Green(util.Sym.Check) + " " + util.C.Gray(row))
+		} else {
+			util.L.Raw("  " + util.C.Gray(util.Sym.Bullet+" "+padEnd(tool.ID, 16)+"not installed"))
+		}
+	}
+
+	util.L.Raw("")
+	util.L.Raw("  " + util.C.Bold("tokless files"))
+	for _, p := range []string{util.InstallMarkerPath(), util.VersionCachePath()} {
+		mark := util.C.Gray(util.Sym.Bullet)
+		if util.Exists(p) {
+			mark = util.C.Green(util.Sym.Check)
+		}
+		util.L.Raw("  " + mark + " " + util.C.Gray(tildePath(p)))
+	}
+
+	util.L.Raw("")
+	util.L.Info("Run " + util.C.Cyan("tokless doctor") + " to check health and updates.")
+	util.L.Raw("")
+	return 0
+}
+
+func infoRow(label, value string) {
+	util.L.Raw("  " + util.C.Gray(padEnd(label, 9)) + value)
+}
+
+// tildePath shortens a home-relative path for display.
+func tildePath(p string) string {
+	if p == "" {
+		return ""
+	}
+	home := util.Home()
+	if home != "" && strings.HasPrefix(p, home) {
+		return "~" + filepath.ToSlash(strings.TrimPrefix(p, home))
+	}
+	return p
+}
+
+func firstField(s, sep string) string {
+	if i := strings.Index(s, sep); i != -1 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/commands/selfupdate.go
+++ b/internal/commands/selfupdate.go
@@ -123,7 +123,18 @@ func runStatus(label string, fn func()) {
 	<-stopped
 }
 
+// runSelfUpdateTo swaps the binary and, on success, re-stamps the install
+// marker so `tokless info` reports the new version instead of the one recorded
+// when the binary was first installed.
 func runSelfUpdateTo(latest string) (bool, bool) {
+	ok, interrupted := selfUpdateExec(latest)
+	if ok && os.Getenv("TOKLESS_TEST") != "1" {
+		util.RefreshInstallMarker(latest)
+	}
+	return ok, interrupted
+}
+
+func selfUpdateExec(latest string) (bool, bool) {
 	if os.Getenv("TOKLESS_TEST") == "1" {
 		return true, false
 	}

--- a/internal/util/install.go
+++ b/internal/util/install.go
@@ -35,20 +35,36 @@ func ToklessDataDir() string {
 func InstallMarkerPath() string { return filepath.Join(ToklessDataDir(), "install.json") }
 
 // WriteInstallMarker records how this binary was installed.
-func WriteInstallMarker(method, path string) error {
+func WriteInstallMarker(method, path, version string) error {
 	if err := EnsureDir(ToklessDataDir()); err != nil {
 		return err
 	}
 	b, err := json.Marshal(InstallRecord{
 		Method:  method,
 		Path:    path,
-		Version: ToklessVersion(),
+		Version: version,
 		At:      time.Now().UTC().Format(time.RFC3339),
 	})
 	if err != nil {
 		return err
 	}
 	return WriteFile(InstallMarkerPath(), string(b))
+}
+
+// RefreshInstallMarker re-stamps the marker after a self-update. The channel
+// that originally installed tokless is preserved — self-update changes the
+// version in place, not how it got there — so only the version and timestamp
+// move. With no prior marker (e.g. a source build), the method is recorded as
+// "self-update", which is what actually replaced the binary.
+func RefreshInstallMarker(version string) {
+	method := "self-update"
+	if raw, ok := ReadFileSafe(InstallMarkerPath()); ok {
+		var m InstallRecord
+		if json.Unmarshal([]byte(raw), &m) == nil && m.Method != "" {
+			method = m.Method
+		}
+	}
+	_ = WriteInstallMarker(method, ToklessAbs(), version)
 }
 
 // InstallInfo reports how the running binary was installed. exact is true only

--- a/internal/util/install.go
+++ b/internal/util/install.go
@@ -1,0 +1,132 @@
+package util
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// InstallRecord is the marker an installer writes so tokless can report,
+// exactly, which channel put it on disk. Path is recorded so a stale marker
+// (installed via curl, later rebuilt from source) can be detected instead of
+// reported as truth.
+type InstallRecord struct {
+	Method  string `json:"method"`
+	Path    string `json:"path"`
+	Version string `json:"version"`
+	At      string `json:"at"`
+}
+
+// ToklessDataDir is the per-user directory tokless keeps its own state in.
+func ToklessDataDir() string {
+	if IsWin {
+		base := os.Getenv("LOCALAPPDATA")
+		if base == "" {
+			base = filepath.Join(Home(), "AppData", "Local")
+		}
+		return filepath.Join(base, "tokless")
+	}
+	return filepath.Join(Home(), ".local", "share", "tokless")
+}
+
+// InstallMarkerPath is where installers write the install record.
+func InstallMarkerPath() string { return filepath.Join(ToklessDataDir(), "install.json") }
+
+// WriteInstallMarker records how this binary was installed.
+func WriteInstallMarker(method, path string) error {
+	if err := EnsureDir(ToklessDataDir()); err != nil {
+		return err
+	}
+	b, err := json.Marshal(InstallRecord{
+		Method:  method,
+		Path:    path,
+		Version: ToklessVersion(),
+		At:      time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return err
+	}
+	return WriteFile(InstallMarkerPath(), string(b))
+}
+
+// InstallInfo reports how the running binary was installed. exact is true only
+// when a marker written by the installer matches this binary; otherwise the
+// method is inferred from the binary's location and callers must present it as
+// a guess.
+func InstallInfo() (rec InstallRecord, exact bool) {
+	exe := ToklessAbs()
+
+	if raw, ok := ReadFileSafe(InstallMarkerPath()); ok {
+		var m InstallRecord
+		if json.Unmarshal([]byte(raw), &m) == nil && m.Method != "" {
+			if samePath(m.Path, exe) {
+				return m, true
+			}
+		}
+	}
+
+	return InstallRecord{Method: inferInstallMethod(exe), Path: exe}, false
+}
+
+// samePath compares two binary paths tolerantly (case/separator on Windows).
+func samePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	norm := func(p string) string {
+		p = filepath.Clean(p)
+		if IsWin {
+			return strings.ToLower(filepath.ToSlash(p))
+		}
+		return p
+	}
+	return norm(a) == norm(b)
+}
+
+// inferInstallMethod guesses the channel from where the binary lives.
+func inferInstallMethod(exe string) string {
+	if exe == "" || !strings.ContainsRune(exe, filepath.Separator) {
+		return "unknown"
+	}
+	slash := filepath.ToSlash(exe)
+	if IsWin {
+		slash = strings.ToLower(slash)
+	}
+	dir := filepath.ToSlash(filepath.Dir(exe))
+
+	switch {
+	// Homebrew's dir is literally "Cellar"; match case-insensitively.
+	case strings.Contains(strings.ToLower(slash), "/cellar/"), strings.HasPrefix(slash, "/opt/homebrew/"),
+		strings.HasPrefix(slash, "/home/linuxbrew/"), strings.HasPrefix(slash, "/usr/local/homebrew/"):
+		return "homebrew"
+	case strings.Contains(slash, "/node_modules/.bin/"):
+		return "npm"
+	case isGoBinDir(dir):
+		return "go install"
+	case samePath(dir, filepath.Join(Home(), ".local", "bin")):
+		return "install script"
+	case strings.Contains(slash, "/dist/release/"), strings.Contains(slash, "/go-build"):
+		return "source build"
+	}
+	return "unknown"
+}
+
+// isGoBinDir reports whether dir is where `go install` drops binaries.
+func isGoBinDir(dir string) bool {
+	if b := os.Getenv("GOBIN"); b != "" && samePath(dir, b) {
+		return true
+	}
+	roots := strings.Split(os.Getenv("GOPATH"), string(os.PathListSeparator))
+	roots = append(roots, filepath.Join(Home(), "go"))
+	for _, r := range roots {
+		if r == "" {
+			continue
+		}
+		if samePath(dir, filepath.Join(r, "bin")) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/install_test.go
+++ b/internal/util/install_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestInferInstallMethod(t *testing.T) {
+	if IsWin {
+		t.Skip("path shapes below are unix-specific")
+	}
+	home := t.TempDir()
+	SetHomeOverride(home)
+	t.Cleanup(func() { SetHomeOverride("") })
+	t.Setenv("GOBIN", "")
+	t.Setenv("GOPATH", "")
+
+	cases := []struct {
+		exe  string
+		want string
+	}{
+		{"/opt/homebrew/bin/tokless", "homebrew"},
+		{"/usr/local/Cellar/tokless/1.0.0/bin/tokless", "homebrew"},
+		{"/usr/lib/node_modules/tokless/node_modules/.bin/tokless", "npm"},
+		{filepath.Join(home, "go", "bin", "tokless"), "go install"},
+		{filepath.Join(home, ".local", "bin", "tokless"), "install script"},
+		{"/Users/x/src/tokless/dist/release/tokless-darwin-arm64", "source build"},
+		{"/usr/bin/tokless", "unknown"},
+		{"tokless", "unknown"},
+	}
+	for _, c := range cases {
+		if got := inferInstallMethod(c.exe); got != c.want {
+			t.Errorf("inferInstallMethod(%q) = %q, want %q", c.exe, got, c.want)
+		}
+	}
+}
+
+// A marker pointing at a different binary is stale (installed one way, then
+// rebuilt another) and must not be reported as exact.
+func TestInstallInfoRejectsStaleMarker(t *testing.T) {
+	home := t.TempDir()
+	SetHomeOverride(home)
+	t.Cleanup(func() { SetHomeOverride("") })
+
+	if err := WriteInstallMarker("homebrew", filepath.Join(home, "nowhere", "tokless")); err != nil {
+		t.Fatal(err)
+	}
+	if _, exact := InstallInfo(); exact {
+		t.Fatal("stale marker reported as exact")
+	}
+
+	if err := WriteInstallMarker("homebrew", ToklessAbs()); err != nil {
+		t.Fatal(err)
+	}
+	rec, exact := InstallInfo()
+	if !exact || rec.Method != "homebrew" {
+		t.Fatalf("matching marker not trusted: %+v exact=%v", rec, exact)
+	}
+}

--- a/internal/util/install_test.go
+++ b/internal/util/install_test.go
@@ -42,18 +42,55 @@ func TestInstallInfoRejectsStaleMarker(t *testing.T) {
 	SetHomeOverride(home)
 	t.Cleanup(func() { SetHomeOverride("") })
 
-	if err := WriteInstallMarker("homebrew", filepath.Join(home, "nowhere", "tokless")); err != nil {
+	if err := WriteInstallMarker("homebrew", filepath.Join(home, "nowhere", "tokless"), "1.0.0"); err != nil {
 		t.Fatal(err)
 	}
 	if _, exact := InstallInfo(); exact {
 		t.Fatal("stale marker reported as exact")
 	}
 
-	if err := WriteInstallMarker("homebrew", ToklessAbs()); err != nil {
+	if err := WriteInstallMarker("homebrew", ToklessAbs(), "1.0.0"); err != nil {
 		t.Fatal(err)
 	}
 	rec, exact := InstallInfo()
 	if !exact || rec.Method != "homebrew" {
 		t.Fatalf("matching marker not trusted: %+v exact=%v", rec, exact)
+	}
+}
+
+// A self-update replaces the binary at the same path, so the marker stays
+// "exact" — it must carry the new version, not the one recorded at install.
+func TestRefreshInstallMarkerAfterSelfUpdate(t *testing.T) {
+	home := t.TempDir()
+	SetHomeOverride(home)
+	t.Cleanup(func() { SetHomeOverride("") })
+
+	if err := WriteInstallMarker("install script", ToklessAbs(), "0.2.6"); err != nil {
+		t.Fatal(err)
+	}
+	RefreshInstallMarker("0.2.7")
+
+	rec, exact := InstallInfo()
+	if !exact {
+		t.Fatal("marker not exact after refresh")
+	}
+	if rec.Version != "0.2.7" {
+		t.Errorf("version = %q, want 0.2.7 (stale version survived self-update)", rec.Version)
+	}
+	if rec.Method != "install script" {
+		t.Errorf("method = %q, want the original channel preserved", rec.Method)
+	}
+}
+
+// With no prior marker, a self-update records itself as the source.
+func TestRefreshInstallMarkerWithoutPrior(t *testing.T) {
+	home := t.TempDir()
+	SetHomeOverride(home)
+	t.Cleanup(func() { SetHomeOverride("") })
+
+	RefreshInstallMarker("0.2.7")
+	rec, exact := InstallInfo()
+	if !exact || rec.Method != "self-update" || rec.Version != "0.2.7" {
+		t.Fatalf("got %+v exact=%v, want self-update/0.2.7/exact", rec, exact)
 	}
 }

--- a/internal/util/versions.go
+++ b/internal/util/versions.go
@@ -37,6 +37,9 @@ func cachePath() string {
 	return filepath.Join(home, ".cache", "tokless", "versions.json")
 }
 
+// VersionCachePath exposes the update-check cache location for reporting.
+func VersionCachePath() string { return cachePath() }
+
 const cacheTTL = 6 * time.Hour
 
 func loadCache() (*cacheShape, bool) {
@@ -282,6 +285,57 @@ func InstalledVersionFor(id string) *string {
 		return ponytailInstalledVersion()
 	}
 	return nil
+}
+
+// InstalledPathFor reports where a tool lives on disk ("" if not found).
+// caveman/ponytail can be installed under several agents; this returns the
+// same first-match dir their version lookup uses.
+func InstalledPathFor(id string) string {
+	switch id {
+	case "rtk":
+		return ResolveRtkBin()
+	case "caveman":
+		for _, dir := range cavemanVersionDirs() {
+			if cavemanInstalled(dir) {
+				return dir
+			}
+		}
+	case "ponytail":
+		for _, dir := range ponytailVersionDirs() {
+			if ponytailInstalled(dir) {
+				return dir
+			}
+		}
+	case "codegraph":
+		return npmPkgDir("@colbymchenry/codegraph")
+	case "context-mode":
+		return npmPkgDir("context-mode")
+	case "tokless":
+		return npmPkgDir("tokless")
+	}
+	return ""
+}
+
+// npmPkgDir locates a globally installed npm package's directory.
+func npmPkgDir(pkg string) string {
+	var dirs []string
+	for _, prefix := range []string{npmPrefix(), userLocalNpmPrefix()} {
+		if prefix == "" {
+			continue
+		}
+		if IsWin {
+			dirs = append(dirs, filepath.Join(prefix, "node_modules", pkg))
+		} else {
+			dirs = append(dirs, filepath.Join(prefix, "lib", "node_modules", pkg))
+		}
+	}
+	dirs = append(dirs, filepath.Join(Home(), ".bun", "install", "global", "node_modules", pkg))
+	for _, d := range dirs {
+		if Exists(filepath.Join(d, "package.json")) {
+			return d
+		}
+	}
+	return ""
 }
 
 const cavemanVersionMarker = ".tokless-version"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -35,6 +35,16 @@ $key.Close()
 $v = & $dest --version 2>$null
 Write-Host "✔ tokless $v ready → $dest" -ForegroundColor Green
 
+# Record the install channel so `tokless info` can report it exactly.
+$dataDir = Join-Path $env:LOCALAPPDATA "tokless"
+New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+@{
+    method  = "install script"
+    path    = $dest
+    version = "$v"
+    at      = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+} | ConvertTo-Json -Compress | Set-Content -Path (Join-Path $dataDir "install.json") -Encoding UTF8
+
 $hadInstallerRun = Test-Path Env:TOKLESS_INSTALLER_RUN
 $prevInstallerRun = $env:TOKLESS_INSTALLER_RUN
 if ([Environment]::UserInteractive -and -not $env:CI) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,14 @@ chmod +x "$tmp"
 install -m 0755 "$tmp" "${DEST}/tokless"
 ok "installed tokless $("${DEST}/tokless" --version 2>/dev/null) → ${DEST}/tokless"
 
+# Record the install channel so `tokless info` can report it exactly.
+data_dir="${HOME}/.local/share/tokless"
+mkdir -p "$data_dir"
+printf '{"method":"install script","path":"%s","version":"%s","at":"%s"}\n' \
+  "${DEST}/tokless" \
+  "$("${DEST}/tokless" --version 2>/dev/null)" \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${data_dir}/install.json"
+
 # Ensure ~/.local/bin is on PATH for new shells.
 case ":${PATH}:" in
   *":${DEST}:"*) : ;;


### PR DESCRIPTION
Closes #22.

Adds `tokless info` — reports how tokless was installed, plus where the binary, agent configs, tools, and tokless-owned files live. Offline by design: health and update checks stay in `doctor`.

### Install detection

Two tiers, and the difference is visible to the user.

**Exact** — the installers now write `~/.local/share/tokless/install.json` (`%LOCALAPPDATA%\tokless` on Windows) recording the channel. `-ldflags` cannot serve here: `install.sh` downloads a prebuilt binary and has no build step to stamp. Any future channel (Homebrew formula, npm postinstall) writes the same file.

The marker records its own install path, so a stale marker — curl-installed, later rebuilt from source — is detected and discarded rather than reported as truth.

**Inferred** — with no valid marker, the method is guessed from the binary location (Homebrew Cellar, `GOBIN`/`GOPATH`, `~/.local/bin`, `node_modules/.bin`) and labelled `guessed from path`. This matters for adoption: every binary installed before this change has no marker, and still reports something useful without an inference being dressed up as fact.

Tool paths resolve per install shape — rtk via its binary, codegraph/context-mode via npm global prefixes, caveman/ponytail via their per-agent plugin dirs, reusing the existing dir lists rather than duplicating them.

### Changes

| File | |
| :--- | :--- |
| `internal/util/install.go` | marker read/write, `ToklessDataDir()`, path inference |
| `internal/commands/info.go` | the command |
| `internal/util/versions.go` | `InstalledPathFor()`, exported `VersionCachePath()` |
| `internal/commands/disable.go` | `uninstall` removes the marker |
| `scripts/install.sh`, `install.ps1` | write the marker |
| `cmd/tokless/main.go`, `README.md` | dispatch + docs |

Additive only — no existing behavior changed.

### Testing

`go build ./...`, `go vet ./...`, `go test ./...` (406 pass). New files are gofmt-clean.

`internal/util/install_test.go` covers the inference cases and stale-marker rejection. Beyond that I exercised all four states end-to-end with real binaries under a temp `HOME` — marker-exact, marker-stale-falls-back, and inference from `~/go/bin` and `~/.local/bin` — and ran the command on a live machine to confirm agent and tool path resolution.

**Not verified:** `install.ps1` — I have no Windows machine. The PowerShell block mirrors the bash one but has not been run.

### Notes

- `caveman`/`ponytail` can be installed under several agents at once; `InstalledPathFor` returns the first match, consistent with the existing version lookup. Listing all of them is a straightforward follow-up if you want it.
- `ToklessDataDir()` hardcodes `~/.local/share` to match the existing convention in `nodelinux.go`. It deliberately does not honor `XDG_DATA_HOME` — doing so in only one of the two places would put the marker where the binary never looks. Worth doing in both, as a separate change.
- A source build placed at `~/.local/bin` infers as `install script`, since that is the installer's directory. Writing a marker corrects it; inference alone cannot distinguish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)