### PR TITLE
feat: self-update the CLI as part of tokless update

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Each tool is wired into each agent through the agent's native config system:
 
 ```
 tokless              Install + wire everything (default; safe to re-run)
-tokless update       Show version diff and upgrade tools
+tokless update       Update the tokless CLI, then show version diff and upgrade tools
 tokless doctor       Show what's wired; warn about broken bits
 tokless index        Build per-project codegraph indexes
 tokless disable      Disable one or more agents

--- a/cmd/tokless/main.go
+++ b/cmd/tokless/main.go
@@ -46,7 +46,7 @@ func helpText() string {
 	return util.C.Bold(util.C.Cyan("tokless")) + " — token-saving for AI coding agents (Claude Code, OpenCode, Codex, Antigravity, GitHub Copilot, Factory Droid, Pi)\n\n" +
 		util.C.Bold("Usage:") + "\n" +
 		"  " + cy("tokless") + "              Install + wire everything (default; safe to re-run)\n" +
-		"  " + cy("tokless update") + "       Show version diff and upgrade tools\n" +
+		"  " + cy("tokless update") + "       Update the tokless CLI, then show version diff and upgrade tools\n" +
 		"  " + cy("tokless doctor") + "       Show what's wired up; warn about anything broken\n" +
 		"  " + cy("tokless index") + "        Build per-project indexes (codegraph) in the current dir\n" +
 		"  " + cy("tokless uninstall") + "    Remove everything tokless ever touched\n\n" +

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -11,6 +11,10 @@ import (
 )
 
 func RunUpdate(opts InitOptions) int {
+	// Before the header: a successful self-update re-execs with the same args,
+	// so the new binary prints the header and runs the tool update itself.
+	MaybeSelfUpdate(opts)
+
 	util.L.Raw("")
 	util.L.Raw("  " + util.C.Bold(util.C.Cyan("tokless update")) + util.C.Gray("  refresh tools to latest"))
 	util.L.Raw("")


### PR DESCRIPTION
Closes #25.

`tokless update` refreshes the five tools but never the CLI itself — so the command named `update` is the one command that leaves tokless stale. Today only bare `tokless` self-updates (via `MaybeSelfUpdate` in `init.go`), which is not where most people would look for it.

This calls the same `MaybeSelfUpdate` from `RunUpdate`, so behavior is identical to the existing path rather than a second implementation:

- skipped on `--dry-run`
- skipped for `-dev` builds
- on success, re-execs with the original args — the new binary then runs `update` again, finds itself current, and continues to the tools

Called before the header, so the header is not printed twice across the re-exec.

### Testing

`go build ./...`, `go vet ./...`, `go test ./...` (404 pass), gofmt clean.

Verified that `--dry-run` still skips the self-update with a non-`-dev` version stamped in, confirming the guard is the `DryRun` check and not just the `-dev` suffix.

**Not verified:** a live self-update through this path. Exercising it means downloading a real release over the running binary and then letting it install tool upgrades on the machine, which I did not want to do to a working setup. The self-update code itself is unchanged — this only adds a call to it from a second entry point.

### Note

Unrelated to this change, but noticed while reading `RunUpdate`: the version-diff loop iterates `core.ListTools()` directly, so `--tools` appears to have no effect on `tokless update` (unlike `init`/`uninstall`, which honor it). Happy to file that separately if it is not intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)