### PR TITLE
feat(proxy): add headroom HTTP proxy lifecycle and agent routing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,7 @@ Apply on every coding task:
 - **Context Tools (context-mode)** — keep raw bytes out, derive answers in-sandbox.
 - **Headroom (headroom)** — explicitly compress large self-contained text when useful.
 
+
 ## Principles
 
 Behavioral guidelines to reduce common LLM coding mistakes.
@@ -140,31 +141,6 @@ Examples:
 - `codegraph_explore("how does auth middleware validate a JWT")`
 - `codegraph_explore("flow from HTTP request to DB query")`
 - `codegraph_explore("OrderService.createOrder callers and blast radius")`
-
-## Context Tools (context-mode)
-
-Sandbox-first tools. Derive answers. Keep raw bytes out, print only needed results.
-
-```
-Use ctx?
-├─ YES → source >~200 lines/KB, multi-source, or worth re-querying → prioritize ctx tools
-└─ NO  → small file, single section, or verbatim-read for editing → Read directly
-```
-
-| Tool | Role | Replaces |
-|------|------|----------|
-| `ctx_execute` | Run code in sandbox. Only stdout enters context. | Bash for analysis tasks |
-| `ctx_execute_file` | Process file in sandbox. Raw bytes never leave. | Read on large files (>200 lines) |
-| `ctx_batch_execute` | Run N commands + auto-index output. Search in same call. Concurrency 1-8. | Multiple Bash + grep |
-| `ctx_index` | Chunk markdown/text into FTS5. Queryable via `ctx_search`. | Manual grep over pasted content |
-| `ctx_search` | Multi-strategy search across indexed content + session memory. Typo correction. | Re-asking user, re-deriving |
-| `ctx_fetch_and_index` | Fetch URL → markdown → index. Cache 24h (override `ttl`). Batch with `requests`+`concurrency`. | WebFetch + re-read |
-
-Examples:
-
-```
-ctx_execute(language:"shell", code:"grep -rn 'TODO' src/ | head -20")
-```
 
 ## Headroom (headroom)
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,16 @@
+{
+  "servers": {
+    "headroom": {
+      "type": "stdio",
+      "command": "/home/hoangp8/.local/bin/tokless",
+      "args": [
+        "run-mcp",
+        "--tool",
+        "headroom",
+        "/home/hoangp8/.local/share/tokless/headroom/bin/headroom",
+        "mcp",
+        "serve"
+      ]
+    }
+  }
+}

--- a/cmd/tokless/main.go
+++ b/cmd/tokless/main.go
@@ -18,6 +18,12 @@ type parsedArgs struct {
 	bools map[string]bool
 }
 
+var (
+	registerAgents    = agents.Register
+	registerTools     = tools.Register
+	ensureProcessPath = util.EnsureProcessPath
+)
+
 // parseArgs mirrors the TS parser: --k=v, --k v, --k, -x short bool.
 func parseArgs(argv []string) parsedArgs {
 	p := parsedArgs{flags: map[string]string{}, bools: map[string]bool{}}
@@ -30,7 +36,7 @@ func parseArgs(argv []string) parsedArgs {
 				p.flags[a[2:]] = argv[i+1]
 				i++
 			} else {
-				if a[2:] == "agents" || a[2:] == "tools" {
+				if a[2:] == "agents" || a[2:] == "tools" || a[2:] == "agent" {
 					p.flags[a[2:]] = ""
 				} else {
 					p.bools[a[2:]] = true
@@ -54,7 +60,8 @@ func helpText() string {
 		"  " + cy("tokless doctor") + "       Show what's wired up; warn about anything broken\n" +
 		"  " + cy("tokless info") + "         Show how tokless was installed, plus paths and config locations\n" +
 		"  " + cy("tokless index") + "        Build per-project indexes (codegraph) in the current dir\n" +
-		"  " + cy("tokless uninstall") + "    Remove everything tokless ever touched\n\n" +
+		"  " + cy("tokless uninstall") + "    Remove everything tokless ever touched\n" +
+		"  " + cy("tokless proxy") + "      Manage the headroom HTTP proxy: up|down|status\n\n" +
 		util.C.Bold("Flags:") + "\n" +
 		"  --agents <list>     Limit to a subset: claude,opencode,codex,antigravity,copilot,droid,grok,pi,omp,kilo,cline,cursor\n" +
 		"  --tools <list>      Limit to a subset: rtk,caveman,ponytail,codegraph,context-mode,headroom\n" +
@@ -95,6 +102,49 @@ func parseList(raw string, ok bool, allowed []string) ([]string, error) {
 	return items, nil
 }
 
+// proxyHelpText prints usage for `tokless proxy <subcommand>`.
+func proxyHelpText() string {
+	cy := util.C.Cyan
+	return util.C.Bold(util.C.Cyan("tokless proxy")) + " — headroom HTTP-proxy daemon (cache mode)\n\n" +
+		util.C.Bold("Usage:") + "\n" +
+		"  " + cy("tokless proxy up") + "       Start the proxy daemon and point agents at it\n" +
+		"  " + cy("tokless proxy down") + "     Unwire agents and stop the proxy daemon\n" +
+		"  " + cy("tokless proxy status") + "   Show daemon + per-agent wiring state\n\n" +
+		util.C.Bold("Flags:") + "\n" +
+		"  --agent <list>     Limit to: claude,codex,opencode,omp,kilo,pi,droid,grok,copilot,cline,cursor,antigravity (default: all)\n" +
+		"  --help             Show this help\n"
+}
+
+// runProxyCli dispatches `tokless proxy up|down|status [--agent ...]`.
+func runProxyCli(argv []string) int {
+	p := parseArgs(argv)
+	if p.bools["verbose"] {
+		util.SetVerbose(true)
+	}
+	if p.bools["help"] || p.bools["h"] || p.cmd == "help" {
+		fmt.Println(proxyHelpText())
+		return 0
+	}
+	agentRaw, agentOK := p.flags["agent"]
+	agentList, err := parseList(agentRaw, agentOK, commands.ProxyAgentIDs())
+	if err != nil {
+		util.L.Err(err.Error())
+		return 2
+	}
+	opts := commands.InitOptions{Agents: agentList}
+	switch p.cmd {
+	case "up":
+		return commands.RunProxyUp(opts)
+	case "down":
+		return commands.RunProxyDown(opts)
+	case "status":
+		return commands.RunProxyStatus(opts)
+	}
+	util.L.Err("Unknown proxy subcommand: " + p.cmd)
+	fmt.Println(proxyHelpText())
+	return 1
+}
+
 func main() {
 	code := run()
 	util.RestoreConsoleCP()
@@ -102,10 +152,9 @@ func main() {
 }
 
 func run() int {
-	agents.Register()
-	tools.Register()
-	util.EnsureProcessPath()
-
+	registerAgents()
+	registerTools()
+	ensureProcessPath()
 	if len(os.Args) >= 3 && os.Args[1] == "run-mcp" {
 		return commands.RunMcp(os.Args[2:])
 	}
@@ -140,6 +189,9 @@ func run() int {
 	}
 	if len(os.Args) >= 3 && os.Args[1] == "copilot-hook" && os.Args[2] == "codegraph-index" {
 		return commands.RunCodegraphIndexHook()
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "proxy" {
+		return runProxyCli(os.Args[2:])
 	}
 
 	p := parseArgs(os.Args[1:])

--- a/cmd/tokless/main.go
+++ b/cmd/tokless/main.go
@@ -57,7 +57,7 @@ func helpText() string {
 		"  " + cy("tokless uninstall") + "    Remove everything tokless ever touched\n\n" +
 		util.C.Bold("Flags:") + "\n" +
 		"  --agents <list>     Limit to a subset: claude,opencode,codex,antigravity,copilot,droid,grok,pi,omp,kilo,cline,cursor\n" +
-		"  --tools <list>      Limit to a subset: rtk,caveman,ponytail,codegraph,context-mode\n" +
+		"  --tools <list>      Limit to a subset: rtk,caveman,ponytail,codegraph,context-mode,headroom\n" +
 		"  --dry-run           Show what would change without writing anything\n" +
 		"  --verbose           Show every step\n\n" +
 		util.C.Gray("Docs: https://github.com/HoangP8/tokless")

--- a/cmd/tokless/main_test.go
+++ b/cmd/tokless/main_test.go
@@ -54,6 +54,31 @@ func TestParseListAcceptsNonemptyLists(t *testing.T) {
 	}
 }
 
+func TestProxyAgentFlagValidation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "bare agent", args: []string{"up", "--agent"}, want: 2},
+		{name: "empty agent", args: []string{"up", "--agent="}, want: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if code := runProxyCli(tt.args); code != tt.want {
+				t.Fatalf("runProxyCli(%q) exit = %d, want %d", tt.args, code, tt.want)
+			}
+		})
+	}
+}
+
+func TestProxyAgentFlagAcceptsValue(t *testing.T) {
+	p := parseArgs([]string{"up", "--agent", "claude"})
+	got, err := parseList(p.flags["agent"], true, []string{"claude"})
+	if err != nil || len(got) != 1 || got[0] != "claude" {
+		t.Fatalf("proxy agent value rejected: got %v, err %v", got, err)
+	}
+}
+
 func TestHelpWinsOverIncompleteListFlag(t *testing.T) {
 	oldArgs := os.Args
 	os.Args = []string{"tokless", "--help", "--agents"}

--- a/docs/headroom-implementation-playbook.md
+++ b/docs/headroom-implementation-playbook.md
@@ -1,0 +1,434 @@
+# Headroom Implementation Playbook
+
+## Scope
+
+Add Headroom as optional Tokless MCP tool. Headroom gives models two explicit
+operations:
+
+- `headroom_compress`: compress supplied text into smaller lossy text.
+- `headroom_retrieve`: recover retained original text by hash during Headroom's
+  local retention window.
+
+This is MCP-first, on-demand compression. Registering server does not cause
+model tool output, conversation context, or arbitrary MCP traffic to be
+compressed automatically. Do not describe it as transparent compression.
+
+Do not implement Headroom's separate proxy mode in this change. Proxy mode has
+different behavior and lifecycle from its direct MCP server.
+
+Success means selected agents receive one managed `headroom` MCP registration,
+only two intended tools are visible/callable through Tokless's wrapper, the
+installation is isolated from user Python, configure/update/remove are
+idempotent, and unsupported native platforms receive useful diagnosis.
+
+## Design Decisions
+
+| Area | Decision |
+| --- | --- |
+| Tool ID | `headroom` |
+| Upstream command | `headroom mcp serve` |
+| Public MCP tools | `headroom_compress`, `headroom_retrieve` |
+| Hidden upstream tools | `headroom_stats`, plus opt-in `headroom_read` |
+| Installation | `uv` managed tool, pinned to managed Python 3.13 |
+| Python isolation | Dedicated Tokless directories, never user site-packages or project venv |
+| Agent wiring | Reuse standard Tokless MCP wiring for every supported agent |
+| Tool visibility | Enforce at JSON-RPC proxy, not only in agent prompt/config |
+| Compression invocation | Explicit model tool call, reinforced by managed instructions where supported |
+| Compression scope | Large, self-contained text; never credentials, private keys, tokens, or opaque binaries |
+| Retrieval | Best effort only; original is local and expires after Headroom TTL, documented as 1 hour |
+
+`headroom_compress` is lossy. Model must retain enough task context to decide
+whether a compressed result is suitable. `headroom_retrieve` is not durable
+storage and must not be used as a replacement for a source file, database, or
+user-visible artifact.
+
+## Phase 1: Manifest And Process Contract
+
+### Files
+
+- Add `internal/tools/headroom.go`.
+- Register it with existing tool registry in `internal/tools`.
+- Add focused tests alongside existing tool lifecycle tests.
+
+### Manifest
+
+Create a `core.ToolManifest` matching existing CodeGraph and Context Mode
+shape:
+
+- `ID: "headroom"`
+- user-facing label and description that say "on-demand MCP compression"
+- install/check/update functions
+- `WireFor` and `UnwireFor` entries for every agent currently supported by
+  generic MCP configuration
+- no ownership of user files beyond Tokless-managed MCP entries and Tokless
+  instruction blocks
+
+Tool command must be represented through existing `util.McpSpawn` machinery,
+not duplicated per agent. The unwrapped child process is:
+
+```text
+headroom mcp serve
+```
+
+Tokless's registered command must run through `tokless run-mcp` so the bounded
+MCP proxy controls the exposed surface. Keep child-command construction in one
+place, likely `internal/util/mcpspawn.go`.
+
+### Expected Process Shape
+
+For every generated agent configuration, semantic process shape is:
+
+```text
+tokless run-mcp --tool headroom <managed-headroom-executable> mcp serve
+```
+
+Use existing exact command serialization conventions for JSON, TOML, YAML, and
+agent-specific configuration. Do not require `headroom` to be on interactive
+shell `PATH`; resolve and register Tokless-managed executable path.
+
+### Acceptance Checks
+
+- Tool registry includes `headroom` exactly once.
+- Spawn resolver produces wrapper command plus child `mcp serve` arguments.
+- A direct Headroom process is never written into agent configuration.
+- Existing CodeGraph and Context Mode process shapes do not change.
+
+## Phase 2: Bounded Generic MCP Proxy
+
+### Problem
+
+`internal/commands/mcp_proxy.go` currently implements Context Mode-specific
+filtering. Headroom upstream exposes more than Tokless promises:
+
+- `headroom_compress`
+- `headroom_retrieve`
+- `headroom_stats`
+- `headroom_read` only when `HEADROOM_MCP_READ` enables it
+
+Prompt text and agent configuration cannot reliably hide tools from every MCP
+host. Enforce least privilege in Tokless's JSON-RPC wrapper.
+
+### Change
+
+Generalize wrapper configuration from a Context Mode special case to a
+tool-to-allowed-tools policy. Keep it data-only and small. For example, central
+policy shape may map:
+
+```text
+context-mode -> existing Context Mode allowlist
+headroom     -> [headroom_compress, headroom_retrieve]
+```
+
+Do not infer access from tool-name prefixes. Unknown tool IDs have no filtered
+policy and retain existing behavior unless wrapper contract explicitly requires
+a policy. Known bounded tools must have a non-empty explicit allowlist.
+
+`run-mcp` needs tool identity before it launches child process. Add a
+backward-compatible explicit `--tool <id>` argument to generated wrapped
+commands. Parse this before child command, consistent with current `--agent`,
+`--workspace`, and `--context-mode` flags. Do not introduce a `--` separator
+unless parser and every writer deliberately support it. Existing old wrapper
+invocations must retain their current behavior until all writers have migrated.
+
+Proxy behavior for bounded tools:
+
+1. Forward initialization and unrelated JSON-RPC methods unchanged.
+2. On `tools/list`, retain upstream payload shape but remove entries whose
+   `name` is not allowed.
+3. On `tools/call`, reject a disallowed tool before forwarding upstream.
+4. Return valid JSON-RPC error with stable machine-readable message; never
+   execute hidden tool as fallback.
+5. Preserve request IDs, JSON decoding limits, cancellation, stderr handling,
+   and child process lifecycle.
+
+Do not edit tool schemas. Passing `headroom_stats` through `tools/list` then
+hoping models ignore it is a failure.
+
+### Tests
+
+Extend `internal/commands/mcp_proxy_test.go` with a fake child MCP server:
+
+- Headroom list forwards only `headroom_compress` and `headroom_retrieve`.
+- `headroom_stats` and `headroom_read` are absent even when child advertises
+  both.
+- allowed call forwards unchanged and returns child result.
+- disallowed call returns error and fake child observes no call.
+- existing Context Mode filtering remains byte-for-byte behaviorally covered.
+- unbounded or legacy invocation retains current pass-through behavior.
+
+Extend `internal/commands/runmcp_test.go`:
+
+- `--tool headroom` parses before child command.
+- child command and arguments remain unchanged.
+- malformed/missing `--tool` value fails before process launch.
+
+## Phase 3: Managed Installation
+
+### Target Layout
+
+Use Tokless-owned directories under existing Tokless application-data root. Add
+one small helper for paths rather than scattering environment variables:
+
+```text
+<tokless-data>/headroom/uv/uv[.exe]
+<tokless-data>/headroom/tools/
+<tokless-data>/headroom/bin/headroom[.exe]
+<tokless-data>/headroom/python/
+```
+
+Set command environment only for Tokless's `uv` execution:
+
+```text
+UV_TOOL_DIR=<tokless-data>/headroom/tools
+UV_TOOL_BIN_DIR=<tokless-data>/headroom/bin
+UV_PYTHON_INSTALL_DIR=<tokless-data>/headroom/python
+UV_MANAGED_PYTHON=1
+```
+
+This prevents writes to `~/.local`, user `uv` tool directories, user Python,
+or project virtual environments. If directory naming must match existing
+Tokless cache/install conventions, follow those conventions instead of adding
+a second root.
+
+### Bootstrap And Install
+
+Install is best effort, with clear stage-specific reporting:
+
+1. Resolve Tokless-managed `uv`; if present, use it.
+2. Otherwise locate system `uv` only if it can run and Tokless can still direct
+   all managed state into Tokless-owned paths.
+3. Otherwise download the official standalone `uv` installer to temporary
+   location, set `UV_INSTALL_DIR` to Tokless-owned bin location and
+   `UV_NO_MODIFY_PATH=1`, then run platform-appropriate official installer.
+4. Resolve installed `uv` by absolute path, never shell profile mutation.
+5. Run `uv tool install --python 3.13 'headroom-ai[mcp]'` with managed-state
+   environment. On update, run equivalent `uv tool install --upgrade` command.
+6. Verify managed `headroom` executable exists and `headroom mcp serve` can
+   start sufficiently to prove entry point is valid. Kill probe cleanly; do not
+   leave a running server.
+
+Never run `pip install`, mutate global Python, add a project dependency, or
+install shell startup snippets.
+
+Avoid hard-coding an upstream package version unless Tokless version policy
+already pins external MCP dependencies. Version policy must be shared with
+existing tool update/status behavior.
+
+### Platform Diagnosis
+
+Headroom supports Python `>=3.10`; Tokless requests Python 3.13 because `uv`
+can manage it independently. Published wheels cover Linux `x86_64`, Linux
+`aarch64`, and Apple Silicon macOS for Python 3.10 through 3.13.
+
+On Windows and Intel macOS, installation may fall back to source build of its
+Rust extension. Detect these platform/architecture combinations before install
+or classify build failure afterward. Report that a Rust/native toolchain may be
+required, include captured concise build tail in verbose mode, and give manual
+recovery command. Do not claim Tokless can guarantee automatic install there.
+
+Installation failures must:
+
+- identify failed stage: `uv bootstrap`, managed Python, package install, or
+  executable verification;
+- preserve original agent configuration by wiring only after install succeeds;
+- not delete a previously working managed install on failed upgrade;
+- return actionable non-zero result;
+- suggest the exact generated command under verbose mode, with no secrets.
+
+### Checks And Updates
+
+`Check` should distinguish:
+
+- missing `uv` or executable;
+- managed executable present but unusable;
+- executable working;
+- unsupported/native-build-risk platform, as warning not a false success.
+
+Use existing `internal/util/versions.go` conventions for installed/latest
+status. Do not implement a second network/version client if `uv` package
+metadata or current Tokless package-check path already answers it.
+
+### Tests
+
+Unit-test path and command builders without network/process dependency:
+
+- managed paths are inside Tokless root;
+- all required `UV_*` values point inside that root;
+- install versus upgrade uses intended flags;
+- no builder yields `pip`, user-site, global Python, or shell-profile command;
+- generated install invocation requests Python 3.13 and `headroom-ai[mcp]`;
+- Windows extension is handled when platform helpers require it;
+- native-build-prone platform errors produce remediation text.
+
+Use existing injectable runner seams to test staged errors. Do not add a live
+network install test to normal suite.
+
+## Phase 4: Generic Agent Wiring
+
+### Required Refactor
+
+Audit each per-agent MCP writer, matcher, verifier, and remover. Several
+currently recognize `codegraph` specially and treat every other MCP as
+`context-mode`. Replace binary assumptions with a small shared MCP definition
+or explicit switch that recognizes `headroom`.
+
+Required affected patterns include:
+
+- `internal/agents/claude.go`: non-CodeGraph wrapped command resolution.
+- `internal/agents/kilo.go`: expected wrapped command matching.
+- `internal/agents/cline.go`: expected wrapped command matching.
+- `internal/agents/omp.go`: non-CodeGraph matcher assumption.
+- `internal/agents/droid.go`: allowed tool-name mapping.
+
+Use exact values for Headroom:
+
+```text
+server name: headroom
+visible tools: headroom_compress, headroom_retrieve
+```
+
+Do not broaden Context Mode permissions or alter CodeGraph's existing
+configuration as part of this refactor.
+
+### Ownership And Idempotence
+
+Reuse `WriteOwner`, tool blocks, and existing config ownership rules:
+
+- Configure only Tokless-owned `headroom` MCP entries.
+- Preserve unrelated user MCP servers, user command overrides, comments, key
+  order, and agent settings as existing writers do.
+- Re-running configure converges to one correct Headroom entry.
+- Update repairs stale Tokless-generated Headroom command shapes.
+- Disable/removal removes only Headroom registration and Headroom-owned
+  instructions; no package removal during selective tool disable.
+- Full uninstall may remove Tokless-owned Headroom managed directories only
+  after all agents and all tools are selected, matching current uninstall
+  safety contract.
+
+Add Headroom package cleanup to `runPurge` only if package is demonstrably
+installed by Tokless in a location current purge contract owns. Since Headroom
+is a private `uv` tool rather than npm global, its cleanup must be a separate,
+safe managed-directory removal, never a broad `uv tool uninstall` against user
+state.
+
+### Test Matrix
+
+For every supported agent:
+
+- configure adds expected Headroom registration once;
+- verification recognizes managed command;
+- user-owned unrelated MCP registration survives;
+- second configure produces no duplicate/drift;
+- selective `--tools headroom` removal removes Headroom only;
+- full disable/uninstall cleans Headroom owner state according to contract;
+- dry-run reports intended operation without filesystem mutation.
+
+Use table-driven fixtures where agent formats share a test helper. Keep
+agent-specific fixture tests where formats differ.
+
+## Phase 5: Model Guidance And Hooks
+
+### Guidance
+
+Add short managed instructions only where Tokless already writes agent
+instructions. Keep them operational:
+
+```text
+For large, self-contained text that must remain in current task, call
+headroom_compress explicitly. It is lossy. Call headroom_retrieve with returned
+hash only when original retained text is needed soon; retrieval is local and
+expires. Never send credentials, tokens, private keys, or sensitive content.
+```
+
+Do not add generic prompt bloat to agents that do not support Tokless-managed
+instruction ownership. Do not claim this causes tool use; models retain choice.
+
+### Hooks
+
+No automatic compression hook in first implementation. Existing hooks cannot
+portably intercept and replace arbitrary agent/MCP tool output before context
+ingestion across all supported hosts. A hook that merely prompts model is
+guidance, not automatic compression.
+
+If future work adds host-specific assistance, it must be opt-in and document:
+
+- supported host and exact event boundary;
+- byte/token threshold;
+- text-only eligibility;
+- exclusions for secrets and user content;
+- failure behavior that passes original content untouched;
+- how compressed content and retrieval hashes appear to model;
+- independent integration tests on that host.
+
+No lifecycle or proxy changes should depend on a hook existing.
+
+## Phase 6: Doctor, Status, And User Output
+
+Integrate with existing doctor and init/update summaries:
+
+- state whether Headroom is installed and which agents are wired;
+- distinguish binary health from agent configuration health;
+- report wrapped direct-MCP behavior as on-demand;
+- report native toolchain warning when applicable;
+- show non-sensitive manual recovery command when install fails;
+- treat temporary retrieval cache absence as normal, not installation failure.
+
+Do not print Headroom source text, retrieval hashes from prior sessions, or
+environment values that could contain credentials.
+
+## Implementation Order
+
+1. Add manifest, managed-path, and command-builder unit tests.
+   Verify: registry/command tests pass without network access.
+2. Generalize `run-mcp` tool policy and add fake-server proxy tests.
+   Verify: only two Headroom tools listed/callable; Context Mode remains intact.
+3. Generalize agent command matching/wiring and add fixture tests.
+   Verify: each supported agent configures, verifies, reconfigures, and removes
+   Headroom without modifying unrelated configuration.
+4. Implement managed `uv` bootstrap/install/check/update/uninstall cleanup.
+   Verify: mocked runner tests cover every stage and preserve working install on
+   failed upgrade.
+5. Add managed instruction text and doctor/status output.
+   Verify: snapshots/assertions state explicit, lossy, temporary semantics.
+6. Run complete verification and repair failures before final review.
+
+## Required Verification Loop
+
+Run these after implementation. Use focused commands first, then full suite.
+
+```bash
+go test ./internal/commands ./internal/tools ./internal/agents ./internal/util
+go test ./...
+go vet ./...
+rtk git diff --check
+```
+
+If repository standard has a different canonical test/lint command, use it in
+addition to these. Test failures must be triaged to root cause, fixed, and
+rerun at focused scope before full suite rerun. Do not mark implementation
+complete with skipped platform/build failure tests unless environment limitation
+is stated and unit coverage proves expected diagnosis path.
+
+Before merge/release, manually inspect generated configs for at least one JSON,
+TOML, and YAML agent format, then run:
+
+```bash
+tokless --agents <fixture-or-test-agent> --tools headroom --yes
+tokless doctor
+tokless disable --agents <fixture-or-test-agent> --tools headroom --yes
+```
+
+Run manual commands only against disposable test homes/config roots supported by
+existing test harness. Never modify developer's live agent configuration while
+validating.
+
+## Non-Goals
+
+- Automatic compression of all model context or MCP responses.
+- Headroom proxy-mode installation or routing.
+- Durable retrieval, cross-machine retrieval, or a Tokless retrieval store.
+- Headroom model-provider configuration or credential management.
+- Global Python, `pip`, npm, or shell-profile changes.
+- Guaranteeing native builds on Windows or Intel macOS without prerequisite
+  toolchains.
+- Exposing `headroom_stats` or `headroom_read` through Tokless.

--- a/internal/agents/antigravity.go
+++ b/internal/agents/antigravity.go
@@ -664,7 +664,7 @@ func ConfigureAntigravityMcp(toolID string) (changed bool, file string) {
 		spawn = util.PickMcpSpawn("codegraph", "serve", "--mcp")
 		RemoveAntigravityCodegraphToolDefs()
 	} else {
-		spawn = util.PickMcpSpawn(toolID)
+		spawn = util.McpSpawnFor(toolID)
 	}
 	allConfigured := true
 	for _, f := range antigravityMcpConfigFiles() {

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -27,7 +27,7 @@ func ConfigureClaudeMcp(toolID string) (changed bool, file string) {
 	if toolID == "codegraph" {
 		spawn = util.WrapAutoIndex("claude", util.PickMcpSpawn("codegraph", "serve", "--mcp"))
 	} else {
-		spawn = util.PickMcpSpawn("context-mode")
+		spawn = util.McpSpawnFor(toolID)
 	}
 	desired := util.NewOrderedMap()
 	desired.Set("type", "stdio")
@@ -66,6 +66,8 @@ func claudeMcpToolNames(toolID string) []string {
 	switch toolID {
 	case "context-mode":
 		return []string{"ctx_search", "ctx_execute", "ctx_execute_file", "ctx_batch_execute", "ctx_index", "ctx_fetch_and_index"}
+	case "headroom":
+		return []string{"headroom_compress", "headroom_retrieve"}
 	case "codegraph":
 		return []string{"codegraph_explore"}
 	}

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -176,6 +176,9 @@ func removeClaudeContextModeWildcard(entries []any) []any {
 func DisallowClaudeMcpTool(toolID string) {
 	p := util.ClaudeCodePaths()
 	raw, ok := util.ReadFileSafe(p.Settings)
+	if util.HasJSONCComments(raw) {
+		return
+	}
 	if !ok {
 		return
 	}

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -344,6 +344,106 @@ func RemoveClaudeMcp(toolID string) bool {
 	return removed
 }
 
+// --- Claude headroom HTTP proxy ---
+
+const claudeProxyEnvKey = "ANTHROPIC_BASE_URL"
+
+func ConfigureClaudeProxy() (changed bool, file string) {
+	url := ProxyEndpointFor("claude")
+	p := util.ClaudeCodePaths()
+	_ = util.EnsureDir(p.Dir)
+	raw, ok := util.ReadFileSafe(p.Settings)
+	if util.HasJSONCComments(raw) {
+		return false, p.Settings
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		if ok {
+			return false, p.Settings
+		}
+		cfg = util.NewOrderedMap()
+	}
+	env := util.NewOrderedMap()
+	if v, ok := cfg.Get("env"); ok {
+		em, isMap := v.(*util.OrderedMap)
+		if !isMap {
+			return false, p.Settings
+		}
+		env = em
+	} else {
+		cfg.Set("env", env)
+	}
+	if v, ok := env.Get(claudeProxyEnvKey); ok {
+		if s, ok := v.(string); ok && s == url {
+			return false, p.Settings
+		}
+		return false, p.Settings
+	}
+	env.Set(claudeProxyEnvKey, url)
+	if err := util.WriteFile(p.Settings, util.StringifyJSON(cfg)); err != nil {
+		return false, p.Settings
+	}
+	return true, p.Settings
+}
+
+// RemoveClaudeProxy deletes env.ANTHROPIC_BASE_URL only when it still equals
+// the url tokless set.
+func RemoveClaudeProxy() bool {
+	url := ProxyEndpointFor("claude")
+	p := util.ClaudeCodePaths()
+	raw, ok := util.ReadFileSafe(p.Settings)
+	if !ok {
+		return false
+	}
+	if util.HasJSONCComments(raw) {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	env, ok := mapChild(cfg, "env")
+	if !ok {
+		return false
+	}
+	v, ok := env.Get(claudeProxyEnvKey)
+	if !ok {
+		return false
+	}
+	s, ok := v.(string)
+	if !ok || s != url {
+		return false
+	}
+	env.Delete(claudeProxyEnvKey)
+	if env.Len() == 0 {
+		cfg.Delete("env")
+	}
+	return util.WriteFile(p.Settings, util.StringifyJSON(cfg)) == nil
+}
+
+// ClaudeProxyWired reports whether ANTHROPIC_BASE_URL is set to url.
+func ClaudeProxyWired() bool {
+	url := ProxyEndpointFor("claude")
+	raw, ok := util.ReadFileSafe(util.ClaudeCodePaths().Settings)
+	if !ok {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	env, ok := mapChild(cfg, "env")
+	if !ok {
+		return false
+	}
+	v, ok := env.Get(claudeProxyEnvKey)
+	if !ok {
+		return false
+	}
+	s, ok := v.(string)
+	return ok && s == url
+}
+
 // claudeMcpEqual compares command/args/env by canonical JSON.
 func claudeMcpEqual(existing any, desired *util.OrderedMap) bool {
 	em, ok := existing.(*util.OrderedMap)

--- a/internal/agents/cline.go
+++ b/internal/agents/cline.go
@@ -202,6 +202,8 @@ func clineExpectedCommand(toolID string, command []string) bool {
 		return len(command) >= 4 && command[2] == "--context-mode" && kiloContextServer(command[3:])
 	case "codegraph":
 		return len(command) >= 7 && command[2] == "--agent" && command[3] == "cline" && kiloCodegraphServer(command[4:])
+	case "headroom":
+		return len(command) == 7 && command[2] == "--tool" && command[3] == "headroom" && kiloHeadroomServer(command[4:])
 	default:
 		return false
 	}

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -79,6 +79,89 @@ func sweepStaleHookStateEntries(raw string) string {
 	return out.String()
 }
 
+// --- Codex headroom HTTP proxy ---
+
+// Codex routing follows headroom's persistent-provider mechanism
+// (headroom/providers/codex/install.py apply_provider_scope).
+const codexProxyProvider = "model_providers.headroom"
+
+func codexProxyBlock(endpoint string) *util.TomlBlock {
+	block := util.NewTomlBlock(codexProxyProvider)
+	block.Set("name", "Headroom persistent proxy")
+	block.Set("base_url", endpoint)
+	block.Set("supports_websockets", true)
+	return block
+}
+
+func codexProxyWritable(raw, endpoint string) bool {
+	for _, kv := range [][2]string{{"model_provider", "headroom"}, {"openai_base_url", endpoint}} {
+		if have := util.GetTomlTopKey(raw, kv[0]); have != "" && have != kv[1] {
+			return false
+		}
+	}
+	return !util.HasBlock(raw, codexProxyProvider) || strings.Contains(raw, util.RenderBlock(codexProxyBlock(endpoint)))
+}
+
+// ConfigureCodexProxy injects headroom's persistent-provider scope into
+// config.toml.
+func ConfigureCodexProxy() (changed bool, file string) {
+	p := util.CodexPathsResolved()
+	raw, ok := util.ReadFileSafe(p.Config)
+	if !ok {
+		return false, p.Config
+	}
+	endpoint := ProxyEndpointFor("codex")
+	if !codexProxyWritable(raw, endpoint) {
+		return false, p.Config
+	}
+	next := util.UpsertBlock(raw, codexProxyBlock(endpoint), false)
+	next = util.SetTomlTopKey(next, "model_provider", "headroom")
+	next = util.SetTomlTopKey(next, "openai_base_url", endpoint)
+	if next == raw {
+		return false, p.Config
+	}
+	_ = util.WriteFile(p.Config, next)
+	return true, p.Config
+}
+
+// RemoveCodexProxy drops the provider scope only while its values still match
+// what tokless set.
+func RemoveCodexProxy() bool {
+	p := util.CodexPathsResolved()
+	raw, ok := util.ReadFileSafe(p.Config)
+	if !ok {
+		return false
+	}
+	endpoint := ProxyEndpointFor("codex")
+	if !codexProxyWritable(raw, endpoint) {
+		return false
+	}
+	next := util.RemoveBlock(raw, codexProxyProvider)
+	next = util.RemoveTomlTopKey(next, "model_provider")
+	next = util.RemoveTomlTopKey(next, "openai_base_url")
+	if next == raw {
+		return false
+	}
+	_ = util.WriteFile(p.Config, next)
+	return true
+}
+
+// CodexProxyWired reports whether config.toml routes through the proxy.
+func CodexProxyWired() bool {
+	raw, ok := util.ReadFileSafe(util.CodexPathsResolved().Config)
+	if !ok {
+		return false
+	}
+	endpoint := ProxyEndpointFor("codex")
+	if util.GetTomlTopKey(raw, "model_provider") != "headroom" {
+		return false
+	}
+	if util.GetTomlTopKey(raw, "openai_base_url") != endpoint {
+		return false
+	}
+	return strings.Contains(raw, util.RenderBlock(codexProxyBlock(endpoint)))
+}
+
 // --- Codex rtk PreToolUse hook ---
 
 const (

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -24,7 +24,7 @@ func ConfigureCodexMcp(toolID string) (changed bool, file string) {
 	if toolID == "codegraph" {
 		spawn = util.WrapAutoIndex("codex", util.PickMcpSpawn("codegraph", "serve", "--mcp"))
 	} else {
-		spawn = util.PickMcpSpawn(toolID)
+		spawn = util.McpSpawnFor(toolID)
 	}
 	block := util.NewTomlBlock("mcp_servers." + toolID)
 	block.Set("command", spawn.Command)

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -17,6 +17,8 @@ var ideProjectRoot string
 
 func SetIdeProjectRoot(p string) { ideProjectRoot = p }
 
+func IdeProjectRoot() string { return ideRoot() }
+
 func ideRoot() string {
 	if ideProjectRoot != "" {
 		return ideProjectRoot
@@ -302,7 +304,7 @@ func ConfigureCopilotMcp(toolID string) (changed bool, file string) {
 	if toolID == "codegraph" {
 		spawn = util.PickMcpSpawn("codegraph", "serve", "--mcp")
 	} else {
-		spawn = util.PickMcpSpawn(toolID)
+		spawn = util.McpSpawnFor(toolID)
 	}
 	desired := util.NewOrderedMap()
 	desired.Set("type", "local")
@@ -387,7 +389,7 @@ func ConfigureCopilotIdeMcp(toolID string) (changed bool, file string) {
 	if toolID == "codegraph" {
 		spawn = util.PickMcpSpawn("codegraph", "serve", "--mcp")
 	} else {
-		spawn = util.PickMcpSpawn(toolID)
+		spawn = util.McpSpawnFor(toolID)
 	}
 	desired := util.NewOrderedMap()
 	desired.Set("type", "stdio")

--- a/internal/agents/cursor.go
+++ b/internal/agents/cursor.go
@@ -16,7 +16,7 @@ func cursorMcpEntry(toolID string) *util.OrderedMap {
 }
 
 func cursorMcpEntryFor(toolID string, windowsBridge bool) *util.OrderedMap {
-	spawn := util.PickMcpSpawn(toolID)
+	spawn := util.McpSpawnFor(toolID)
 	if toolID == "codegraph" {
 		spawn = util.WrapAutoIndex("cursor", util.PickMcpSpawn("codegraph", "serve", "--mcp"))
 		spawn.Args = append([]string{"run-mcp", "--agent", "cursor", "--workspace", "${workspaceFolder}"}, spawn.Args[3:]...)

--- a/internal/agents/droid.go
+++ b/internal/agents/droid.go
@@ -82,6 +82,7 @@ var droid = &core.AgentManifest{
 var droidEnabledTools = map[string][]string{
 	"codegraph":    CodegraphDroidToolNames,
 	"context-mode": ContextModeDroidToolNames,
+	"headroom":     HeadroomDroidToolNames,
 }
 
 func ConfigureDroidMcp(toolID string) (changed bool, file string) {
@@ -89,7 +90,7 @@ func ConfigureDroidMcp(toolID string) (changed bool, file string) {
 	if toolID == "codegraph" {
 		spawn = util.PickMcpSpawn("codegraph", "serve", "--mcp")
 	} else {
-		spawn = util.PickMcpSpawn(toolID)
+		spawn = util.McpSpawnFor(toolID)
 	}
 
 	f := droidMcpFile()
@@ -211,6 +212,8 @@ var ContextModeDroidToolNames = []string{
 var CodegraphDroidToolNames = []string{
 	"codegraph_explore",
 }
+
+var HeadroomDroidToolNames = []string{"headroom_compress", "headroom_retrieve"}
 
 // --- hooks management ---
 

--- a/internal/agents/droid.go
+++ b/internal/agents/droid.go
@@ -96,6 +96,9 @@ func ConfigureDroidMcp(toolID string) (changed bool, file string) {
 	f := droidMcpFile()
 	_ = util.EnsureDir(filepath.Dir(f))
 	raw, _ := util.ReadFileSafe(f)
+	if util.HasJSONCComments(raw) {
+		return false, f
+	}
 	cfg := util.TryParseJsonc(raw)
 	if cfg == nil {
 		cfg = util.NewOrderedMap()
@@ -124,7 +127,9 @@ func ConfigureDroidMcp(toolID string) (changed bool, file string) {
 
 	servers.Set(toolID, entry)
 	if next := util.StringifyJSON(cfg); next != raw {
-		_ = util.WriteFile(f, next)
+		if err := util.WriteFile(f, next); err != nil {
+			return false, f
+		}
 		changed = true
 		file = f
 	}
@@ -164,6 +169,9 @@ func RemoveDroidMcp(toolID string) bool {
 	if !ok {
 		return false
 	}
+	if util.HasJSONCComments(raw) {
+		return false
+	}
 	cfg := util.TryParseJsonc(raw)
 	if cfg == nil {
 		return false
@@ -180,8 +188,7 @@ func RemoveDroidMcp(toolID string) bool {
 		return false
 	}
 	sm.Delete(toolID)
-	_ = util.WriteFile(f, util.StringifyJSON(cfg))
-	return true
+	return util.WriteFile(f, util.StringifyJSON(cfg)) == nil
 }
 
 // DroidMcpHas reports whether ~/.factory/mcp.json registers the tool.

--- a/internal/agents/droid.go
+++ b/internal/agents/droid.go
@@ -460,3 +460,147 @@ func argsEq(a any, b []string) bool {
 	}
 	return true
 }
+
+// --- Droid headroom HTTP proxy ---
+
+const (
+	droidProxyModel        = "headroom"
+	droidProxyDisplayName  = "Headroom Proxy"
+	droidProxyProviderKind = "generic-chat-completion-api"
+)
+
+func droidSettingsFile() string { return filepath.Join(droidDir(), "settings.json") }
+
+// droidProxyEntry builds the customModels entry pointing at the headroom daemon.
+func droidProxyEntry(endpoint string) *util.OrderedMap {
+	entry := util.NewOrderedMap()
+	entry.Set("model", droidProxyModel)
+	entry.Set("displayName", droidProxyDisplayName)
+	entry.Set("baseUrl", endpoint)
+	entry.Set("provider", droidProxyProviderKind)
+	return entry
+}
+
+// ConfigureDroidProxy appends the headroom entry to customModels in
+// settings.json, pointing at the OpenAI-compatible headroom daemon endpoint.
+func ConfigureDroidProxy() (changed bool, file string) {
+	f := droidSettingsFile()
+	_ = util.EnsureDir(droidDir())
+	raw, ok := util.ReadFileSafe(f)
+	if util.HasJSONCComments(raw) {
+		return false, f
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		if ok {
+			return false, f
+		}
+		cfg = util.NewOrderedMap()
+	}
+	endpoint := ProxyEndpointFor("droid")
+	var models []any
+	if v, ok := cfg.Get("customModels"); ok {
+		arr, isArr := v.([]any)
+		if !isArr {
+			return false, f
+		}
+		models = arr
+	}
+	for _, existing := range models {
+		em, isMap := existing.(*util.OrderedMap)
+		if !isMap {
+			continue
+		}
+		model, _ := em.Get("model")
+		display, _ := em.Get("displayName")
+		if model == droidProxyModel && display == droidProxyDisplayName {
+			return false, f
+		}
+	}
+	cfg.Set("customModels", append(models, droidProxyEntry(endpoint)))
+	if err := util.WriteFile(f, util.StringifyJSON(cfg)); err != nil {
+		return false, f
+	}
+	return true, f
+}
+
+// RemoveDroidProxy drops any customModels entry pointing at our endpoint,
+// keeping every other entry.
+func RemoveDroidProxy() bool {
+	f := droidSettingsFile()
+	raw, ok := util.ReadFileSafe(f)
+	if !ok {
+		return false
+	}
+	if util.HasJSONCComments(raw) {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	v, ok := cfg.Get("customModels")
+	if !ok {
+		return false
+	}
+	models, ok := v.([]any)
+	if !ok {
+		return false
+	}
+	endpoint := ProxyEndpointFor("droid")
+	kept := make([]any, 0, len(models))
+	dropped := false
+	for _, entry := range models {
+		em, isMap := entry.(*util.OrderedMap)
+		if !isMap {
+			kept = append(kept, entry)
+			continue
+		}
+		if jsonEqual(em, droidProxyEntry(endpoint)) {
+			dropped = true
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	if !dropped {
+		return false
+	}
+	if len(kept) == 0 {
+		cfg.Delete("customModels")
+	} else {
+		cfg.Set("customModels", kept)
+	}
+	return util.WriteFile(f, util.StringifyJSON(cfg)) == nil
+}
+
+// DroidProxyWired reports whether any customModels entry points at the
+// headroom daemon endpoint.
+func DroidProxyWired() bool {
+	raw, ok := util.ReadFileSafe(droidSettingsFile())
+	if !ok {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	v, ok := cfg.Get("customModels")
+	if !ok {
+		return false
+	}
+	models, ok := v.([]any)
+	if !ok {
+		return false
+	}
+	endpoint := ProxyEndpointFor("droid")
+	for _, entry := range models {
+		em, isMap := entry.(*util.OrderedMap)
+		if !isMap {
+			continue
+		}
+		if jsonEqual(em, droidProxyEntry(endpoint)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agents/grok.go
+++ b/internal/agents/grok.go
@@ -39,7 +39,7 @@ func ConfigureGrokMcp(toolID string) (changed bool, file string, err error) {
 	if toolID == "codegraph" {
 		spawn = util.WrapAutoIndex("grok", util.PickMcpSpawn("codegraph", "serve", "--mcp"))
 	} else {
-		spawn = util.PickMcpSpawn(toolID)
+		spawn = util.McpSpawnFor(toolID)
 	}
 	block := util.NewTomlBlock("mcp_servers." + toolID)
 	block.Set("command", spawn.Command)
@@ -85,6 +85,12 @@ func GrokContextModeMcpHas() bool {
 	return ok && enabled && !grokMcpDisabled(raw, "context-mode") && grokToklessCommand(command) && grokContextModeArgs(args)
 }
 
+func GrokHeadroomMcpHas() bool {
+	raw, ok := util.ReadFileSafe(grokConfigFile())
+	command, args, enabled, ok := grokMcpFields(raw, "headroom")
+	return ok && enabled && !grokMcpDisabled(raw, "headroom") && grokToklessCommand(command) && grokHeadroomArgs(args)
+}
+
 func grokMcpDisabled(raw, toolID string) bool {
 	_, _, servers, ok := grokDisabledServers(raw)
 	if !ok {
@@ -125,6 +131,11 @@ func grokContextModeArgs(args []string) bool {
 	}
 	return len(tail) == 2 && grokCommandName(command, "npx") &&
 		tail[0] == "--no-install" && tail[1] == "context-mode"
+}
+
+func grokHeadroomArgs(args []string) bool {
+	command, tail, ok := grokMcpCommand(args, []string{"run-mcp", "--tool", "headroom"})
+	return ok && grokCommandName(command, "headroom") && len(tail) == 2 && tail[0] == "mcp" && tail[1] == "serve"
 }
 
 // grokMcpCommand accepts direct commands or Tokless's Windows cmd /c wrapper.

--- a/internal/agents/kilo.go
+++ b/internal/agents/kilo.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -474,4 +475,137 @@ var kilo = &core.AgentManifest{
 	Detect: func() core.Detection {
 		return detectVSCodeAgent("kilo", util.KiloPathsResolved().Dir, kiloKnownBinDirs(), "kilocode.kilo-code")
 	},
+}
+
+// --- Kilo headroom HTTP proxy ---
+
+const kiloProxyProvider = "tokless-headroom"
+
+// kiloProxyProviderEntry builds the opencode-style provider entry injected
+// into provider.<id>.
+func kiloProxyProviderEntry(endpoint string) *util.OrderedMap {
+	entry := util.NewOrderedMap()
+	entry.Set("npm", "@ai-sdk/openai-compatible")
+	entry.Set("name", "Headroom Proxy")
+	options := util.NewOrderedMap()
+	options.Set("baseURL", endpoint)
+	entry.Set("options", options)
+	model := util.NewOrderedMap()
+	model.Set("name", "Headroom")
+	model.Set("tool_call", true)
+	limit := util.NewOrderedMap()
+	limit.Set("context", 128000)
+	limit.Set("output", 16384)
+	model.Set("limit", limit)
+	models := util.NewOrderedMap()
+	models.Set("headroom", model)
+	entry.Set("models", models)
+	return entry
+}
+
+// ConfigureKiloProxy injects provider.tokless-headroom into kilo.jsonc,
+// pointing at the OpenAI-compatible headroom daemon endpoint.
+func ConfigureKiloProxy() (changed bool, file string) {
+	p := util.KiloPathsResolved()
+	_ = util.EnsureDir(p.Dir)
+	raw, ok := util.ReadFileSafe(p.Config)
+	if util.HasJSONCComments(raw) {
+		return false, p.Config
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		if ok {
+			return false, p.Config
+		}
+		cfg = util.NewOrderedMap()
+	}
+	providers, ok := mapChild(cfg, "provider")
+	if !ok {
+		if _, present := cfg.Get("provider"); present {
+			return false, p.Config
+		}
+		providers = util.NewOrderedMap()
+		cfg.Set("provider", providers)
+	}
+	desired := kiloProxyProviderEntry(ProxyEndpointFor("kilo"))
+	if existing, ok := providers.Get(kiloProxyProvider); ok {
+		if jsonEqual(existing, desired) {
+			return false, p.Config
+		}
+		return false, p.Config
+	}
+	providers.Set(kiloProxyProvider, desired)
+	if err := util.WriteFile(p.Config, util.StringifyJSON(cfg)); err != nil {
+		return false, p.Config
+	}
+	return true, p.Config
+}
+
+// RemoveKiloProxy deletes provider.tokless-headroom only while its value still
+// equals what tokless injected.
+func RemoveKiloProxy() bool {
+	p := util.KiloPathsResolved()
+	raw, ok := util.ReadFileSafe(p.Config)
+	if !ok {
+		return false
+	}
+	if util.HasJSONCComments(raw) {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	providers, ok := mapChild(cfg, "provider")
+	if !ok {
+		return false
+	}
+	existing, ok := providers.Get(kiloProxyProvider)
+	if !ok || !jsonEqual(existing, kiloProxyProviderEntry(ProxyEndpointFor("kilo"))) {
+		return false
+	}
+	providers.Delete(kiloProxyProvider)
+	if providers.Len() == 0 {
+		cfg.Delete("provider")
+	}
+	return util.WriteFile(p.Config, util.StringifyJSON(cfg)) == nil
+}
+
+// KiloProxyWired reports whether provider.tokless-headroom points at the
+// headroom daemon endpoint.
+func KiloProxyWired() bool {
+	raw, ok := util.ReadFileSafe(util.KiloPathsResolved().Config)
+	if !ok {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	providers, ok := mapChild(cfg, "provider")
+	if !ok {
+		return false
+	}
+	existing, ok := providers.Get(kiloProxyProvider)
+	return ok && jsonEqual(existing, kiloProxyProviderEntry(ProxyEndpointFor("kilo")))
+}
+
+// jsonEqual compares two JSON values by canonical form.
+func jsonEqual(a, b any) bool {
+	return canonicalJSON(a) == canonicalJSON(b)
+}
+
+func canonicalJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	var m any
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	if err := dec.Decode(&m); err != nil {
+		return string(b)
+	}
+	b2, _ := json.Marshal(m)
+	return string(b2)
 }

--- a/internal/agents/kilo.go
+++ b/internal/agents/kilo.go
@@ -222,9 +222,15 @@ func kiloExpectedCommand(toolID string, command []string) bool {
 		return len(command) >= 4 && command[2] == "--context-mode" && kiloContextServer(command[3:])
 	case "codegraph":
 		return len(command) >= 7 && command[2] == "--agent" && command[3] == "kilo" && kiloCodegraphServer(command[4:])
+	case "headroom":
+		return len(command) == 7 && command[2] == "--tool" && command[3] == "headroom" && kiloHeadroomServer(command[4:])
 	default:
 		return false
 	}
+}
+
+func kiloHeadroomServer(command []string) bool {
+	return len(command) == 3 && kiloCommandBase(command[0]) == "headroom" && command[1] == "mcp" && command[2] == "serve"
 }
 
 func kiloContextServer(command []string) bool {

--- a/internal/agents/omp.go
+++ b/internal/agents/omp.go
@@ -301,3 +301,204 @@ func ompMcpEntry(toolID string) *util.OrderedMap {
 func HasOmpRtkExtension() bool {
 	return util.Exists(filepath.Join(ompExtensionsDir(), "tokless-rtk.ts"))
 }
+
+// --- Oh My Pi (omp) headroom HTTP proxy ---
+
+func ompModelsFile() string { return filepath.Join(OmpAgentDirResolved(), "models.yml") }
+
+var ompWriteFile = util.WriteFile
+
+// ConfigureOmpProxy points providers.anthropic.baseUrl at the proxy via a
+// careful text edit that preserves the rest of models.yml.
+func ConfigureOmpProxy() (changed bool, file string) {
+	baseURL := ProxyEndpointFor("omp")
+	p := ompModelsFile()
+	raw, ok := util.ReadFileSafe(p)
+	if !ok {
+		return false, p
+	}
+	next, ok := ompYamlWriteBaseURL(raw, baseURL)
+	if !ok || next == raw {
+		return false, p
+	}
+	if err := ompWriteFile(p, next); err != nil {
+		return false, p
+	}
+	return true, p
+}
+
+// RemoveOmpProxy deletes providers.anthropic.baseUrl only when it still equals
+// the url tokless set.
+func RemoveOmpProxy() bool {
+	baseURL := ProxyEndpointFor("omp")
+	p := ompModelsFile()
+	raw, ok := util.ReadFileSafe(p)
+	if !ok {
+		return false
+	}
+	next, ok := ompYamlRemoveBaseURL(raw, baseURL)
+	if !ok || next == raw {
+		return false
+	}
+	if err := ompWriteFile(p, next); err != nil {
+		return false
+	}
+	return true
+}
+
+// OmpProxyWired reports whether providers.anthropic.baseUrl is set to baseURL.
+func OmpProxyWired() bool {
+	baseURL := ProxyEndpointFor("omp")
+	raw, ok := util.ReadFileSafe(ompModelsFile())
+	if !ok {
+		return false
+	}
+	return ompYamlBaseURL(raw) == baseURL
+}
+
+// ompYamlKeyRe matches a YAML mapping-key line: indent, key, then anything.
+var ompYamlKeyRe = regexp.MustCompile(`^(\s*)([A-Za-z0-9_.-]+):(\s*)(.*)$`)
+
+// ompYamlKeyLine parses a mapping-key line. (indent, key, hasValue, value).
+func ompYamlKeyLine(line string) (int, string, bool, string) {
+	m := ompYamlKeyRe.FindStringSubmatch(line)
+	if m == nil {
+		return -1, "", false, ""
+	}
+	rest := strings.TrimSpace(m[4])
+	if rest != "" {
+		if i := strings.Index(rest, " #"); i >= 0 {
+			rest = strings.TrimSpace(rest[:i])
+		}
+		if rest != "" {
+			return len(m[1]), m[2], true, rest
+		}
+	}
+	return len(m[1]), m[2], false, ""
+}
+
+// ompYamlRef locates the providers → anthropic → baseUrl chain in models.yml.
+type ompYamlRef struct {
+	prov, provEnd, ant, antIndent, antEnd, base int // line indexes; -1 when absent
+}
+
+func ompYamlScan(raw string) ompYamlRef {
+	ref := ompYamlRef{prov: -1, ant: -1, antIndent: 0, antEnd: -1, base: -1}
+	lines := strings.Split(raw, "\n")
+	for i, l := range lines {
+		if ind, key, _, _ := ompYamlKeyLine(l); ind == 0 && key == "providers" {
+			ref.prov = i
+			break
+		}
+	}
+	if ref.prov == -1 {
+		return ref
+	}
+	ref.provEnd = len(lines)
+	for i := ref.prov + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		if ind, _, _, _ := ompYamlKeyLine(lines[i]); ind == 0 {
+			ref.provEnd = i
+			break
+		}
+	}
+	directIndent := -1
+	for i := ref.prov + 1; i < ref.provEnd; i++ {
+		if ind, _, _, _ := ompYamlKeyLine(lines[i]); ind > 0 {
+			directIndent = ind
+			break
+		}
+	}
+	for i := ref.prov + 1; i < ref.provEnd; i++ {
+		if ind, key, _, _ := ompYamlKeyLine(lines[i]); key == "anthropic" && ind == directIndent {
+			ref.ant, ref.antIndent = i, ind
+			break
+		}
+	}
+	if ref.ant == -1 {
+		ref.antIndent = 2
+		ref.antEnd = ref.provEnd
+		return ref
+	}
+	ref.antEnd = ref.provEnd
+	for i := ref.ant + 1; i < ref.provEnd; i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		if ind, _, _, _ := ompYamlKeyLine(lines[i]); ind >= 0 && ind <= ref.antIndent {
+			ref.antEnd = i
+			break
+		}
+	}
+	for i := ref.ant + 1; i < ref.antEnd; i++ {
+		if ind, key, _, _ := ompYamlKeyLine(lines[i]); key == "baseUrl" && ind == ref.antIndent+2 {
+			ref.base = i
+			break
+		}
+	}
+	return ref
+}
+
+// ompYamlBaseURL returns the current providers.anthropic.baseUrl value.
+func ompYamlBaseURL(raw string) string {
+	ref := ompYamlScan(raw)
+	if ref.base == -1 {
+		return ""
+	}
+	_, _, _, v := ompYamlKeyLine(strings.Split(raw, "\n")[ref.base])
+	return v
+}
+
+// ompYamlWriteBaseURL sets providers.anthropic.baseUrl = url, preserving the
+// rest byte-for-byte. ok=false when a differing value blocks the edit.
+func ompYamlWriteBaseURL(raw, url string) (string, bool) {
+	lines := strings.Split(raw, "\n")
+	ref := ompYamlScan(raw)
+	switch {
+	case ref.base >= 0:
+		if _, _, _, have := ompYamlKeyLine(lines[ref.base]); have == url {
+			return raw, true
+		} else if have != "" {
+			return raw, false
+		}
+		lines[ref.base] = strings.Repeat(" ", ref.antIndent+2) + "baseUrl: " + url
+	case ref.ant >= 0:
+		line := strings.Repeat(" ", ref.antIndent+2) + "baseUrl: " + url
+		lines = ompYamlInsertLine(lines, ref.antEnd, line)
+	case ref.prov >= 0:
+		lines = ompYamlInsertLines(lines, ref.provEnd, "  anthropic:", "    baseUrl: "+url)
+	default:
+		out := raw
+		if out != "" && !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		out += "providers:" + "\n" + "  anthropic:" + "\n" + "    baseUrl: " + url + "\n"
+		return out, true
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// ompYamlRemoveBaseURL deletes providers.anthropic.baseUrl only when it still
+// equals url; ok=false when absent or differing.
+func ompYamlRemoveBaseURL(raw, url string) (string, bool) {
+	lines := strings.Split(raw, "\n")
+	ref := ompYamlScan(raw)
+	if ref.base == -1 {
+		return raw, false
+	}
+	if _, _, _, have := ompYamlKeyLine(lines[ref.base]); have != url {
+		return raw, false
+	}
+	lines = append(lines[:ref.base], lines[ref.base+1:]...)
+	return strings.Join(lines, "\n"), true
+}
+
+func ompYamlInsertLine(lines []string, at int, line string) []string {
+	return append(lines[:at], append([]string{line}, lines[at:]...)...)
+}
+
+func ompYamlInsertLines(lines []string, at int, inserted ...string) []string {
+	return append(lines[:at], append(inserted, lines[at:]...)...)
+}

--- a/internal/agents/omp.go
+++ b/internal/agents/omp.go
@@ -172,7 +172,10 @@ func ompMcpManaged(toolID string, existing any) bool {
 	if toolID == "codegraph" {
 		return len(values) >= 6 && values[0] == "run-mcp" && values[1] == "--agent" && values[2] == "omp" && ompCodegraphTarget(values[3:])
 	}
-	return len(values) >= 3 && values[0] == "run-mcp" && values[1] == "--context-mode" && ompContextModeTarget(values[2:])
+	if toolID == "context-mode" {
+		return len(values) >= 3 && values[0] == "run-mcp" && values[1] == "--context-mode" && ompContextModeTarget(values[2:])
+	}
+	return toolID == "headroom" && len(values) == 5 && values[0] == "run-mcp" && values[1] == "--tool" && values[2] == "headroom" && ompHeadroomTarget(values[3:])
 }
 
 func ompCodegraphTarget(args []string) bool {
@@ -197,6 +200,10 @@ func ompContextModeTarget(args []string) bool {
 	}
 	return len(args) == 3 && isOmpBinary(args[0], "npx") && args[1] == "--no-install" && args[2] == "context-mode" ||
 		len(args) == 5 && isOmpCmd(args[0]) && args[1] == "/c" && isOmpBinary(args[2], "npx") && args[3] == "--no-install" && args[4] == "context-mode"
+}
+
+func ompHeadroomTarget(args []string) bool {
+	return len(args) == 3 && isOmpBinary(args[0], "headroom") && args[1] == "mcp" && args[2] == "serve"
 }
 
 func isOmpCmd(command string) bool { return isOmpBinary(command, "cmd") }
@@ -282,7 +289,7 @@ func ompMcpEntry(toolID string) *util.OrderedMap {
 	if toolID == "codegraph" {
 		spawn = util.WrapAutoIndex("omp", util.PickMcpSpawn("codegraph", "serve", "--mcp"))
 	} else {
-		spawn = util.PickMcpSpawn("context-mode")
+		spawn = util.McpSpawnFor(toolID)
 	}
 	entry := util.NewOrderedMap()
 	entry.Set("type", "stdio")

--- a/internal/agents/opencode.go
+++ b/internal/agents/opencode.go
@@ -13,6 +13,9 @@ func ConfigureOpenCodeMcp(toolID string) (changed bool, file string) {
 	p := util.OpenCodePathsResolved()
 	_ = util.EnsureDir(p.Dir)
 	raw, _ := util.ReadFileSafe(p.Config)
+	if util.HasJSONCComments(raw) {
+		return false, p.Config
+	}
 	cfg := util.TryParseJsonc(raw)
 	if cfg == nil {
 		cfg = util.NewOrderedMap()
@@ -43,7 +46,9 @@ func ConfigureOpenCodeMcp(toolID string) (changed bool, file string) {
 		}
 	}
 	mcp.Set(toolID, desired)
-	_ = util.WriteFile(p.Config, util.StringifyJSON(cfg))
+	if err := util.WriteFile(p.Config, util.StringifyJSON(cfg)); err != nil {
+		return false, p.Config
+	}
 	return true, p.Config
 }
 
@@ -51,6 +56,9 @@ func RemoveOpenCodeMcp(toolID string) bool {
 	p := util.OpenCodePathsResolved()
 	raw, ok := util.ReadFileSafe(p.Config)
 	if !ok {
+		return false
+	}
+	if util.HasJSONCComments(raw) {
 		return false
 	}
 	cfg := util.TryParseJsonc(raw)

--- a/internal/agents/opencode.go
+++ b/internal/agents/opencode.go
@@ -69,8 +69,133 @@ func RemoveOpenCodeMcp(toolID string) bool {
 		return false
 	}
 	mcp.Delete(toolID)
-	_ = util.WriteFile(p.Config, util.StringifyJSON(cfg))
-	return true
+	return util.WriteFile(p.Config, util.StringifyJSON(cfg)) == nil
+}
+
+// --- OpenCode headroom HTTP proxy ---
+
+func openCodeProxyProviderBlock(baseURL string) *util.OrderedMap {
+	gpt4o := util.NewOrderedMap()
+	gpt4o.Set("name", "GPT-4o")
+	gpt4oLimit := util.NewOrderedMap()
+	gpt4oLimit.Set("context", 128000)
+	gpt4oLimit.Set("output", 16384)
+	gpt4o.Set("limit", gpt4oLimit)
+
+	gpt41 := util.NewOrderedMap()
+	gpt41.Set("name", "GPT-4.1")
+	gpt41Limit := util.NewOrderedMap()
+	gpt41Limit.Set("context", 1048576)
+	gpt41Limit.Set("output", 32768)
+	gpt41.Set("limit", gpt41Limit)
+
+	models := util.NewOrderedMap()
+	models.Set("gpt-4o", gpt4o)
+	models.Set("gpt-4.1", gpt41)
+
+	opts := util.NewOrderedMap()
+	opts.Set("baseURL", baseURL)
+
+	block := util.NewOrderedMap()
+	block.Set("npm", "@ai-sdk/openai-compatible")
+	block.Set("name", "Headroom Proxy")
+	block.Set("options", opts)
+	block.Set("models", models)
+	return block
+}
+
+// ConfigureOpenCodeProxy merges the `headroom` provider into the top-level
+// `provider` object of the opencode config.
+func ConfigureOpenCodeProxy() (changed bool, file string) {
+	p := util.OpenCodePathsResolved()
+	raw, ok := util.ReadFileSafe(p.Config)
+	if !ok {
+		return false, p.Config
+	}
+	if util.HasJSONCComments(raw) {
+		return false, p.Config
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false, p.Config
+	}
+	var providers *util.OrderedMap
+	if v, ok := cfg.Get("provider"); ok {
+		em, isMap := v.(*util.OrderedMap)
+		if !isMap {
+			return false, p.Config
+		}
+		providers = em
+	} else {
+		providers = util.NewOrderedMap()
+		cfg.Set("provider", providers)
+	}
+	entry := openCodeProxyProviderBlock(ProxyEndpointFor("opencode"))
+	if existing, ok := providers.Get("headroom"); ok {
+		if util.StringifyJSON(existing) == util.StringifyJSON(entry) {
+			return false, p.Config
+		}
+		return false, p.Config
+	}
+	providers.Set("headroom", entry)
+	if err := util.WriteFile(p.Config, util.StringifyJSON(cfg)); err != nil {
+		return false, p.Config
+	}
+	return true, p.Config
+}
+
+// RemoveOpenCodeProxy deletes the `headroom` provider only when it still
+// matches what tokless set.
+func RemoveOpenCodeProxy() bool {
+	p := util.OpenCodePathsResolved()
+	raw, ok := util.ReadFileSafe(p.Config)
+	if !ok {
+		return false
+	}
+	if util.HasJSONCComments(raw) {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	providers, ok := mapChild(cfg, "provider")
+	if !ok {
+		return false
+	}
+	existing, ok := providers.Get("headroom")
+	if !ok {
+		return false
+	}
+	if util.StringifyJSON(existing) != util.StringifyJSON(openCodeProxyProviderBlock(ProxyEndpointFor("opencode"))) {
+		return false
+	}
+	providers.Delete("headroom")
+	if providers.Len() == 0 {
+		cfg.Delete("provider")
+	}
+	return util.WriteFile(p.Config, util.StringifyJSON(cfg)) == nil
+}
+
+// OpenCodeProxyWired reports whether the `headroom` provider is set to baseURL.
+func OpenCodeProxyWired() bool {
+	raw, ok := util.ReadFileSafe(util.OpenCodePathsResolved().Config)
+	if !ok {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	providers, ok := mapChild(cfg, "provider")
+	if !ok {
+		return false
+	}
+	existing, ok := providers.Get("headroom")
+	if !ok {
+		return false
+	}
+	return util.StringifyJSON(existing) == util.StringifyJSON(openCodeProxyProviderBlock(ProxyEndpointFor("opencode")))
 }
 
 func notDisabled(m *util.OrderedMap) bool {

--- a/internal/agents/opencode.go
+++ b/internal/agents/opencode.go
@@ -26,7 +26,7 @@ func ConfigureOpenCodeMcp(toolID string) (changed bool, file string) {
 	if toolID == "codegraph" {
 		spawn = util.WrapAutoIndex("opencode", util.PickMcpSpawn("codegraph", "serve", "--mcp"))
 	} else {
-		spawn = util.PickMcpSpawn("context-mode")
+		spawn = util.McpSpawnFor(toolID)
 	}
 	command := append([]string{spawn.Command}, spawn.Args...)
 	desired := util.NewOrderedMap()

--- a/internal/agents/opencode_test.go
+++ b/internal/agents/opencode_test.go
@@ -1,0 +1,35 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+func TestConfigureOpenCodeMcpRefusesJSONCComments(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+
+	path := util.OpenCodePathsResolved().Config
+	seed := `{
+  // Keep this user comment.
+  "theme": "dark"
+}
+`
+	if err := util.WriteFile(path, seed); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _ := ConfigureOpenCodeMcp("context-mode"); changed {
+		t.Fatal("must refuse MCP configuration change")
+	}
+	got, ok := util.ReadFileSafe(path)
+	if !ok {
+		t.Fatal("OpenCode config missing")
+	}
+	if got != seed {
+		t.Fatalf("JSONC config changed:\n%s", got)
+	}
+}

--- a/internal/agents/pi.go
+++ b/internal/agents/pi.go
@@ -407,6 +407,9 @@ func PiUpdatePackages() {
 
 func ConfigurePiMcp(toolID string) (changed bool, file string) {
 	spawn := util.PickMcpSpawn(toolID, "serve", "--mcp")
+	if toolID == "headroom" {
+		spawn = util.McpSpawnFor(toolID)
+	}
 	f := piMcpFile()
 	_ = util.EnsureDir(filepath.Dir(f))
 	raw, _ := util.ReadFileSafe(f)

--- a/internal/agents/pi.go
+++ b/internal/agents/pi.go
@@ -506,3 +506,109 @@ func PiMcpHasAny() bool {
 	sm, ok := s.(*util.OrderedMap)
 	return ok && sm.Len() > 0
 }
+
+// --- Pi headroom HTTP proxy ---
+
+const piProxyProvider = "tokless-headroom"
+
+func piModelsFile() string { return filepath.Join(piAgentDir(), "models.json") }
+
+// piProxyProviderEntry builds the provider entry injected into providers.<id>.
+func piProxyProviderEntry(endpoint string) *util.OrderedMap {
+	entry := util.NewOrderedMap()
+	entry.Set("baseUrl", endpoint)
+	entry.Set("api", "openai-completions")
+	entry.Set("apiKey", "tokless")
+	model := util.NewOrderedMap()
+	model.Set("id", "headroom")
+	model.Set("reasoning", false)
+	entry.Set("models", []any{model})
+	return entry
+}
+
+// ConfigurePiProxy injects providers.tokless-headroom into models.json,
+// pointing at the OpenAI-compatible headroom daemon endpoint.
+func ConfigurePiProxy() (changed bool, file string) {
+	f := piModelsFile()
+	_ = util.EnsureDir(piAgentDir())
+	raw, ok := util.ReadFileSafe(f)
+	if util.HasJSONCComments(raw) {
+		return false, f
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		if ok {
+			return false, f
+		}
+		cfg = util.NewOrderedMap()
+	}
+	providers, ok := mapChild(cfg, "providers")
+	if !ok {
+		if _, present := cfg.Get("providers"); present {
+			return false, f
+		}
+		providers = util.NewOrderedMap()
+		cfg.Set("providers", providers)
+	}
+	desired := piProxyProviderEntry(ProxyEndpointFor("pi"))
+	if existing, ok := providers.Get(piProxyProvider); ok {
+		if jsonEqual(existing, desired) {
+			return false, f
+		}
+		return false, f
+	}
+	providers.Set(piProxyProvider, desired)
+	if err := util.WriteFile(f, util.StringifyJSON(cfg)); err != nil {
+		return false, f
+	}
+	return true, f
+}
+
+// RemovePiProxy deletes providers.tokless-headroom only while its value still
+// equals what tokless injected; a differing user entry is left untouched.
+func RemovePiProxy() bool {
+	f := piModelsFile()
+	raw, ok := util.ReadFileSafe(f)
+	if !ok {
+		return false
+	}
+	if util.HasJSONCComments(raw) {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	providers, ok := mapChild(cfg, "providers")
+	if !ok {
+		return false
+	}
+	existing, ok := providers.Get(piProxyProvider)
+	if !ok || !jsonEqual(existing, piProxyProviderEntry(ProxyEndpointFor("pi"))) {
+		return false
+	}
+	providers.Delete(piProxyProvider)
+	if providers.Len() == 0 {
+		cfg.Delete("providers")
+	}
+	return util.WriteFile(f, util.StringifyJSON(cfg)) == nil
+}
+
+// PiProxyWired reports whether providers.tokless-headroom points at the
+// headroom daemon endpoint.
+func PiProxyWired() bool {
+	raw, ok := util.ReadFileSafe(piModelsFile())
+	if !ok {
+		return false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false
+	}
+	providers, ok := mapChild(cfg, "providers")
+	if !ok {
+		return false
+	}
+	existing, ok := providers.Get(piProxyProvider)
+	return ok && jsonEqual(existing, piProxyProviderEntry(ProxyEndpointFor("pi")))
+}

--- a/internal/agents/proxy_detection.go
+++ b/internal/agents/proxy_detection.go
@@ -1,0 +1,277 @@
+package agents
+
+import (
+	"os"
+	"strings"
+
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+// ProxyProtocol describes the wire protocol a client uses for proxy traffic.
+type ProxyProtocol string
+
+const (
+	ProxyProtocolAnthropicNative  ProxyProtocol = "anthropic-native"
+	ProxyProtocolOpenAICompatible ProxyProtocol = "openai-compatible"
+	ProxyProtocolNone             ProxyProtocol = "none"
+)
+
+// ProxyWireKind describes how tokless can reach an agent.
+type ProxyWireKind string
+
+const (
+	ProxyWireManagedRoute     ProxyWireKind = "managed-route"
+	ProxyWireAdditiveProvider ProxyWireKind = "additive-provider/model"
+	ProxyWireManual           ProxyWireKind = "manual"
+	ProxyWireMCPOnly          ProxyWireKind = "MCP-only"
+)
+
+// ProxyConfigState is an observed, read-only configuration state.
+type ProxyConfigState string
+
+const (
+	ProxyStateManaged      ProxyConfigState = "managed"
+	ProxyStateUnconfigured ProxyConfigState = "unconfigured"
+	ProxyStateAbsent       ProxyConfigState = "absent"
+	ProxyStateForeignBYOK  ProxyConfigState = "foreign-byok"
+	ProxyStateConflict     ProxyConfigState = "conflict"
+	ProxyStateUnreadable   ProxyConfigState = "unreadable"
+	ProxyStateUnknown      ProxyConfigState = "unknown"
+)
+
+// ProxyCapability is static metadata. Detail is intentionally bounded and non-secret.
+type ProxyCapability struct {
+	ID       string
+	Protocol ProxyProtocol
+	WireKind ProxyWireKind
+}
+
+// ProxyDetection combines static capability with observed local state.
+type ProxyDetection struct {
+	Capability ProxyCapability
+	State      ProxyConfigState
+	Detail     string
+}
+
+// Default Headroom cache mode preserves provider-prefix caching. Tokless does
+// not enable semantic response caching for arbitrary BYOK endpoints.
+const ProxyCachePolicy = "cache mode preserves provider-prefix cache; semantic response cache disabled"
+
+var proxyCapabilities = map[string]ProxyCapability{
+	"claude":      {"claude", ProxyProtocolAnthropicNative, ProxyWireManagedRoute},
+	"omp":         {"omp", ProxyProtocolAnthropicNative, ProxyWireManagedRoute},
+	"codex":       {"codex", ProxyProtocolOpenAICompatible, ProxyWireManagedRoute},
+	"opencode":    {"opencode", ProxyProtocolOpenAICompatible, ProxyWireAdditiveProvider},
+	"kilo":        {"kilo", ProxyProtocolOpenAICompatible, ProxyWireAdditiveProvider},
+	"pi":          {"pi", ProxyProtocolOpenAICompatible, ProxyWireAdditiveProvider},
+	"droid":       {"droid", ProxyProtocolOpenAICompatible, ProxyWireAdditiveProvider},
+	"grok":        {"grok", ProxyProtocolOpenAICompatible, ProxyWireManual},
+	"copilot":     {"copilot", ProxyProtocolOpenAICompatible, ProxyWireManual},
+	"cline":       {"cline", ProxyProtocolNone, ProxyWireManual},
+	"cursor":      {"cursor", ProxyProtocolNone, ProxyWireManual},
+	"antigravity": {"antigravity", ProxyProtocolNone, ProxyWireMCPOnly},
+}
+
+// ProxyCapabilities returns the static proxy capability registry.
+func ProxyCapabilities() map[string]ProxyCapability {
+	out := make(map[string]ProxyCapability, len(proxyCapabilities))
+	for id, capability := range proxyCapabilities {
+		out[id] = capability
+	}
+	return out
+}
+
+func proxyDetection(id, detail string, state ProxyConfigState) ProxyDetection {
+	return ProxyDetection{Capability: proxyCapabilities[id], State: state, Detail: detail}
+}
+
+func readProxyConfig(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	return string(raw), err
+}
+
+// DetectProxy reads only documented proxy slots. It never writes, probes, or
+// returns configuration values beyond fixed status text.
+func DetectProxy(id string) ProxyDetection {
+	capability, ok := proxyCapabilities[id]
+	if !ok {
+		return ProxyDetection{Capability: ProxyCapability{ID: id, Protocol: ProxyProtocolNone, WireKind: ProxyWireManual}, State: ProxyStateUnknown, Detail: "unsupported agent"}
+	}
+	switch id {
+	case "claude":
+		return detectClaudeProxy(capability)
+	case "omp":
+		return detectOmpProxy(capability)
+	case "codex":
+		return detectCodexProxy(capability)
+	case "opencode":
+		return detectProviderProxy(capability, util.OpenCodePathsResolved().Config, "provider", "headroom", openCodeProxyProviderBlock(ProxyEndpointFor(id)))
+	case "kilo":
+		return detectProviderProxy(capability, util.KiloPathsResolved().Config, "provider", kiloProxyProvider, kiloProxyProviderEntry(ProxyEndpointFor(id)))
+	case "pi":
+		return detectProviderProxy(capability, piModelsFile(), "providers", piProxyProvider, piProxyProviderEntry(ProxyEndpointFor(id)))
+	case "droid":
+		return detectDroidProxy(capability)
+	case "grok":
+		return detectManualEnv(capability, "GROK_MODELS_BASE_URL", util.HeadroomProxyOpenAIURL())
+	case "copilot":
+		return detectManualEnv(capability, "COPILOT_PROVIDER_BASE_URL", util.HeadroomProxyOpenAIURL())
+	case "cline", "cursor":
+		return proxyDetection(id, "manual configuration not observable", ProxyStateUnknown)
+	case "antigravity":
+		return proxyDetection(id, "no client base-URL knob", ProxyStateUnknown)
+	default:
+		return proxyDetection(id, "unsupported agent", ProxyStateUnknown)
+	}
+}
+
+func detectClaudeProxy(cap ProxyCapability) ProxyDetection {
+	path := util.ClaudeCodePaths().Settings
+	raw, err := readProxyConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return proxyDetection(cap.ID, "settings file absent", ProxyStateAbsent)
+		}
+		return proxyDetection(cap.ID, "settings unreadable", ProxyStateUnreadable)
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return proxyDetection(cap.ID, "settings unreadable", ProxyStateUnreadable)
+	}
+	container, ok := mapChild(cfg, "env")
+	if !ok {
+		if _, present := cfg.Get("env"); present {
+			return proxyDetection(cap.ID, "documented env slot unreadable", ProxyStateUnreadable)
+		}
+		return proxyDetection(cap.ID, "documented endpoint not configured", ProxyStateUnconfigured)
+	}
+	v, present := container.Get(claudeProxyEnvKey)
+	if !present {
+		return proxyDetection(cap.ID, "documented endpoint not configured", ProxyStateUnconfigured)
+	}
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return proxyDetection(cap.ID, "documented endpoint unreadable", ProxyStateUnreadable)
+	}
+	if s == ProxyEndpointFor(cap.ID) {
+		return proxyDetection(cap.ID, "exact managed endpoint", ProxyStateManaged)
+	}
+	return proxyDetection(cap.ID, "documented endpoint differs", ProxyStateForeignBYOK)
+}
+
+func detectOmpProxy(cap ProxyCapability) ProxyDetection {
+	path := ompModelsFile()
+	raw, err := readProxyConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return proxyDetection(cap.ID, "models file absent", ProxyStateAbsent)
+		}
+		return proxyDetection(cap.ID, "models file unreadable", ProxyStateUnreadable)
+	}
+	if strings.TrimSpace(raw) == "" {
+		return proxyDetection(cap.ID, "models file unreadable", ProxyStateUnreadable)
+	}
+	return proxyDetection(cap.ID, "verified YAML parsing unavailable; config state unknown", ProxyStateUnknown)
+}
+
+func detectCodexProxy(cap ProxyCapability) ProxyDetection {
+	path := util.CodexPathsResolved().Config
+	raw, err := readProxyConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return proxyDetection(cap.ID, "config file absent", ProxyStateAbsent)
+		}
+		return proxyDetection(cap.ID, "config unreadable", ProxyStateUnreadable)
+	}
+	if strings.TrimSpace(raw) == "" {
+		return proxyDetection(cap.ID, "config unreadable", ProxyStateUnreadable)
+	}
+	return proxyDetection(cap.ID, "verified TOML parsing unavailable; config state unknown", ProxyStateUnknown)
+}
+
+func detectProviderProxy(cap ProxyCapability, path, containerKey, reserved string, desired any) ProxyDetection {
+	raw, err := readProxyConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return proxyDetection(cap.ID, "config file absent", ProxyStateAbsent)
+		}
+		return proxyDetection(cap.ID, "config unreadable", ProxyStateUnreadable)
+	}
+	if util.HasJSONCComments(raw) {
+		return proxyDetection(cap.ID, "comment-bearing config not safely inspectable", ProxyStateUnreadable)
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return proxyDetection(cap.ID, "config unreadable", ProxyStateUnreadable)
+	}
+	providers, ok := mapChild(cfg, containerKey)
+	if !ok {
+		if _, present := cfg.Get(containerKey); present {
+			return proxyDetection(cap.ID, "documented provider slot unreadable", ProxyStateUnreadable)
+		}
+		return proxyDetection(cap.ID, "reserved provider slot not configured", ProxyStateUnconfigured)
+	}
+	existing, present := providers.Get(reserved)
+	if present {
+		if jsonEqual(existing, desired) || util.StringifyJSON(existing) == util.StringifyJSON(desired) {
+			return proxyDetection(cap.ID, "exact reserved provider", ProxyStateManaged)
+		}
+		return proxyDetection(cap.ID, "reserved provider differs", ProxyStateConflict)
+	}
+	if providers.Len() > 0 {
+		return proxyDetection(cap.ID, "foreign provider present; reserved slot absent", ProxyStateUnconfigured)
+	}
+	return proxyDetection(cap.ID, "reserved provider slot not configured", ProxyStateUnconfigured)
+}
+
+func detectDroidProxy(cap ProxyCapability) ProxyDetection {
+	path := droidSettingsFile()
+	raw, err := readProxyConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return proxyDetection(cap.ID, "settings file absent", ProxyStateAbsent)
+		}
+		return proxyDetection(cap.ID, "settings unreadable", ProxyStateUnreadable)
+	}
+	if util.HasJSONCComments(raw) {
+		return proxyDetection(cap.ID, "comment-bearing config not safely inspectable", ProxyStateUnreadable)
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return proxyDetection(cap.ID, "settings unreadable", ProxyStateUnreadable)
+	}
+	v, present := cfg.Get("customModels")
+	if !present {
+		return proxyDetection(cap.ID, "reserved custom model absent", ProxyStateUnconfigured)
+	}
+	models, ok := v.([]any)
+	if !ok {
+		return proxyDetection(cap.ID, "customModels slot unreadable", ProxyStateUnreadable)
+	}
+	for _, entry := range models {
+		m, ok := entry.(*util.OrderedMap)
+		if !ok {
+			continue
+		}
+		model, _ := m.Get("model")
+		display, _ := m.Get("displayName")
+		if model == droidProxyModel && display == droidProxyDisplayName {
+			if jsonEqual(m, droidProxyEntry(ProxyEndpointFor(cap.ID))) {
+				return proxyDetection(cap.ID, "exact reserved custom model", ProxyStateManaged)
+			}
+			return proxyDetection(cap.ID, "reserved custom model differs", ProxyStateConflict)
+		}
+	}
+	return proxyDetection(cap.ID, "reserved custom model absent", ProxyStateUnconfigured)
+}
+
+func detectManualEnv(cap ProxyCapability, key, endpoint string) ProxyDetection {
+	value, set := os.LookupEnv(key)
+	if !set || strings.TrimSpace(value) == "" {
+		return proxyDetection(cap.ID, "manual endpoint not observed", ProxyStateUnknown)
+	}
+	if value == endpoint {
+		return proxyDetection(cap.ID, "manual endpoint equals proxy; ownership unknown", ProxyStateUnknown)
+	}
+	return proxyDetection(cap.ID, "documented environment endpoint differs", ProxyStateForeignBYOK)
+}

--- a/internal/agents/proxy_kdp_test.go
+++ b/internal/agents/proxy_kdp_test.go
@@ -1,0 +1,411 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+// proxyEndpoint is the OpenAI-compatible endpoint derived from the daemon URL.
+const proxyEndpoint = proxyTestURL + "/v1"
+
+func kiloProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("KILO_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+func piProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+func droidProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+type proxyConfigCase struct {
+	name         string
+	seed         string
+	skipConfig   bool
+	wantConfigCh bool
+	wantWired    bool
+	wantRemove   bool
+	wantContains []string
+	wantRetained []string
+	wantAbsent   []string
+	wantNoFile   bool
+}
+
+type proxyAgentOps struct {
+	configPath func(t *testing.T) string
+	home       func(t *testing.T)
+	configure  func() (bool, string)
+	wired      func() bool
+	remove     func() bool
+}
+
+func runProxyConfigCases(t *testing.T, ops proxyAgentOps, cases []proxyConfigCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ops.home(t)
+			cfg := ops.configPath(t)
+			if tc.seed != "" {
+				if err := util.WriteFile(cfg, tc.seed); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if !tc.skipConfig {
+				changed, file := ops.configure()
+				if changed != tc.wantConfigCh {
+					t.Fatalf("Configure changed = %v, want %v", changed, tc.wantConfigCh)
+				}
+				if file != cfg {
+					t.Fatalf("Configure file = %q, want %q", file, cfg)
+				}
+			}
+			if got := ops.wired(); got != tc.wantWired {
+				t.Fatalf("Wired = %v, want %v", got, tc.wantWired)
+			}
+			if raw, _ := util.ReadFileSafe(cfg); len(tc.wantContains) > 0 {
+				for _, want := range tc.wantContains {
+					if !strings.Contains(raw, want) {
+						t.Fatalf("missing %q in config:%s", want, raw)
+					}
+				}
+			}
+			if got := ops.remove(); got != tc.wantRemove {
+				t.Fatalf("Remove = %v, want %v", got, tc.wantRemove)
+			}
+			if ops.wired() {
+				t.Fatal("still wired after Remove")
+			}
+			raw, ok := util.ReadFileSafe(cfg)
+			if tc.wantNoFile {
+				if ok {
+					t.Fatalf("config file was created:%s", raw)
+				}
+				return
+			}
+			for _, want := range tc.wantRetained {
+				if !strings.Contains(raw, want) {
+					t.Fatalf("missing %q after Remove:%s", want, raw)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(raw, absent) {
+					t.Fatalf("unexpected %q after Remove:%s", absent, raw)
+				}
+			}
+		})
+	}
+}
+
+func TestKiloProxyConfigurators(t *testing.T) {
+	injected := `{
+  "provider": {
+    "tokless-headroom": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Headroom Proxy",
+      "options": { "baseURL": "http://127.0.0.1:8787/v1" },
+      "models": {
+        "headroom": { "name": "Headroom", "tool_call": true, "limit": { "context": 128000, "output": 16384 } }
+      }
+    }
+  }
+}`
+	reordered := `{
+  "provider": {
+    "tokless-headroom": {
+      "models": {
+        "headroom": { "limit": { "output": 16384, "context": 128000 }, "tool_call": true, "name": "Headroom" }
+      },
+      "options": { "baseURL": "http://127.0.0.1:8787/v1" },
+      "name": "Headroom Proxy",
+      "npm": "@ai-sdk/openai-compatible"
+    }
+  }
+}`
+	cases := []proxyConfigCase{
+		{
+			name:         "inject writes provider entry",
+			wantConfigCh: true,
+			wantWired:    true,
+			wantRemove:   true,
+			wantContains: []string{
+				`"tokless-headroom"`,
+				`"npm": "@ai-sdk/openai-compatible"`,
+				`"baseURL": "http://127.0.0.1:8787/v1"`,
+				`"tool_call": true`,
+				`"context": 128000`,
+			},
+			wantAbsent: []string{proxyEndpoint},
+		},
+		{
+			name:         "idempotent when already wired",
+			seed:         injected,
+			wantConfigCh: false,
+			wantWired:    true,
+			wantRemove:   true,
+		},
+		{
+			name:         "idempotent even with reordered keys",
+			seed:         reordered,
+			wantConfigCh: false,
+			wantWired:    true,
+			wantRemove:   true,
+		},
+		{
+			name:         "refuses differing existing entry",
+			seed:         `{"provider":{"tokless-headroom":{"npm":"@ai-sdk/openai-compatible","name":"User","options":{"baseURL":"http://user.example:9999/v1"},"models":{}}}}`,
+			wantConfigCh: false,
+			wantWired:    false,
+			wantRemove:   false,
+			wantRetained: []string{`"http://user.example:9999/v1"`},
+		},
+		{
+			name:         "refuses non-object provider field",
+			seed:         `{"provider":"user"}`,
+			wantConfigCh: false,
+			wantWired:    false,
+			wantRemove:   false,
+			wantRetained: []string{`"provider":"user"`},
+		},
+		{
+			name:         "merges under existing provider object",
+			seed:         `{"provider":{"user-provider":{"npm":"@ai-sdk/openai","name":"User","options":{"baseURL":"http://u.example:1/v1"},"models":{}}}}`,
+			wantConfigCh: true,
+			wantWired:    true,
+			wantRemove:   true,
+			wantContains: []string{`"user-provider"`, `"http://u.example:1/v1"`, `"tokless-headroom"`},
+			wantRetained: []string{`"user-provider"`, `"http://u.example:1/v1"`},
+			wantAbsent:   []string{proxyEndpoint},
+		},
+		{
+			name:       "wired false when file missing",
+			skipConfig: true,
+			wantWired:  false,
+			wantRemove: false,
+			wantNoFile: true,
+		},
+	}
+	runProxyConfigCases(t, proxyAgentOps{
+		home:       kiloProxyTestHome,
+		configPath: func(t *testing.T) string { return util.KiloPathsResolved().Config },
+		configure:  ConfigureKiloProxy,
+		wired:      KiloProxyWired,
+		remove:     RemoveKiloProxy,
+	}, cases)
+}
+
+func TestPiProxyConfigurators(t *testing.T) {
+	injected := `{
+  "providers": {
+    "tokless-headroom": {
+      "baseUrl": "http://127.0.0.1:8787/v1",
+      "api": "openai-completions",
+      "apiKey": "tokless",
+      "models": [ { "id": "headroom", "reasoning": false } ]
+    }
+  }
+}`
+	cases := []proxyConfigCase{
+		{
+			name:         "inject writes provider entry",
+			wantConfigCh: true,
+			wantWired:    true,
+			wantRemove:   true,
+			wantContains: []string{
+				`"tokless-headroom"`,
+				`"baseUrl": "http://127.0.0.1:8787/v1"`,
+				`"api": "openai-completions"`,
+				`"apiKey": "tokless"`,
+				`"reasoning": false`,
+			},
+			wantAbsent: []string{proxyEndpoint},
+		},
+		{
+			name:         "idempotent when already wired",
+			seed:         injected,
+			wantConfigCh: false,
+			wantWired:    true,
+			wantRemove:   true,
+		},
+		{
+			name:         "refuses differing existing entry",
+			seed:         `{"providers":{"tokless-headroom":{"baseUrl":"http://user.example:9999/v1","api":"openai","apiKey":"news","models":[]}}}`,
+			wantConfigCh: false,
+			wantWired:    false,
+			wantRemove:   false,
+			wantRetained: []string{`"http://user.example:9999/v1"`},
+		},
+		{
+			name:         "refuses non-object providers field",
+			seed:         `{"providers":"user"}`,
+			wantConfigCh: false,
+			wantWired:    false,
+			wantRemove:   false,
+			wantRetained: []string{`"providers":"user"`},
+		},
+		{
+			name:         "merges under existing providers object",
+			seed:         `{"providers":{"user-provider":{"baseUrl":"http://u.example:1/v1","api":"openai","apiKey":"k","models":[]}}}`,
+			wantConfigCh: true,
+			wantWired:    true,
+			wantRemove:   true,
+			wantContains: []string{`"user-provider"`, `"http://u.example:1/v1"`, `"tokless-headroom"`},
+			wantRetained: []string{`"user-provider"`, `"http://u.example:1/v1"`},
+			wantAbsent:   []string{proxyEndpoint},
+		},
+		{
+			name:       "wired false when file missing",
+			skipConfig: true,
+			wantWired:  false,
+			wantRemove: false,
+			wantNoFile: true,
+		},
+	}
+	runProxyConfigCases(t, proxyAgentOps{
+		home:       piProxyTestHome,
+		configPath: func(t *testing.T) string { return filepath.Join(piAgentDir(), "models.json") },
+		configure:  ConfigurePiProxy,
+		wired:      PiProxyWired,
+		remove:     RemovePiProxy,
+	}, cases)
+}
+
+func TestDroidProxyConfigurators(t *testing.T) {
+	injected := `{
+  "customModels": [
+    {
+      "model": "headroom",
+      "displayName": "Headroom Proxy",
+      "baseUrl": "http://127.0.0.1:8787/v1",
+      "provider": "generic-chat-completion-api"
+    }
+  ]
+}`
+	cases := []proxyConfigCase{
+		{
+			name:         "inject appends customModel entry",
+			wantConfigCh: true,
+			wantWired:    true,
+			wantRemove:   true,
+			wantContains: []string{
+				`"model": "headroom"`,
+				`"displayName": "Headroom Proxy"`,
+				`"baseUrl": "http://127.0.0.1:8787/v1"`,
+				`"provider": "generic-chat-completion-api"`,
+			},
+			wantAbsent: []string{proxyEndpoint},
+		},
+		{
+			name:         "idempotent when already wired",
+			seed:         injected,
+			wantConfigCh: false,
+			wantWired:    true,
+			wantRemove:   true,
+		},
+		{
+			name:         "refuses differing existing entry",
+			seed:         `{"customModels":[{"model":"headroom","displayName":"Headroom Proxy","baseUrl":"http://user.example:9999/v1","provider":"generic-chat-completion-api"}]}`,
+			wantConfigCh: false,
+			wantWired:    false,
+			wantRemove:   false,
+			wantRetained: []string{`"http://user.example:9999/v1"`},
+		},
+		{
+			name:         "refuses non-array customModels field",
+			seed:         `{"customModels":"user"}`,
+			wantConfigCh: false,
+			wantWired:    false,
+			wantRemove:   false,
+			wantRetained: []string{`"customModels":"user"`},
+		},
+		{
+			name: "remove keeps other customModels entries",
+			seed: `{"customModels":[
+				{"model":"headroom","displayName":"Headroom Proxy","baseUrl":"http://127.0.0.1:8787/v1","provider":"generic-chat-completion-api"},
+				{"model":"gpt","displayName":"User","baseUrl":"http://u.example:1/v1","provider":"generic-chat-completion-api"}
+			]}`,
+			wantConfigCh: false,
+			wantWired:    true,
+			wantRemove:   true,
+			wantRetained: []string{`"User"`, `"http://u.example:1/v1"`},
+			wantAbsent:   []string{proxyEndpoint},
+		},
+		{
+			name:         "remove keeps user entry sharing proxy URL",
+			seed:         `{"customModels":[{"model":"mine","displayName":"My Model","baseUrl":"http://127.0.0.1:8787/v1","provider":"generic-chat-completion-api"}]}`,
+			wantConfigCh: true,
+			wantWired:    true,
+			wantRemove:   true,
+			wantRetained: []string{`"mine"`, `"My Model"`, proxyEndpoint},
+			wantAbsent:   []string{`"Headroom Proxy"`},
+		},
+		{
+			name:       "wired false when file missing",
+			skipConfig: true,
+			wantWired:  false,
+			wantRemove: false,
+			wantNoFile: true,
+		},
+	}
+	runProxyConfigCases(t, proxyAgentOps{
+		home:       droidProxyTestHome,
+		configPath: func(t *testing.T) string { return droidSettingsFile() },
+		configure:  ConfigureDroidProxy,
+		wired:      DroidProxyWired,
+		remove:     RemoveDroidProxy,
+	}, cases)
+}
+
+func TestProxyConfiguratorsRefusePersistenceFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		home      func(*testing.T)
+		path      func() string
+		configure func() (bool, string)
+		remove    func() bool
+	}{
+		{"claude", claudeProxyTestHome, func() string { return util.ClaudeCodePaths().Settings }, ConfigureClaudeProxy, RemoveClaudeProxy},
+		{"opencode", opencodeProxyTestHome, func() string { return util.OpenCodePathsResolved().Config }, ConfigureOpenCodeProxy, RemoveOpenCodeProxy},
+		{"kilo", kiloProxyTestHome, func() string { return util.KiloPathsResolved().Config }, ConfigureKiloProxy, RemoveKiloProxy},
+		{"pi", piProxyTestHome, func() string { return filepath.Join(piAgentDir(), "models.json") }, ConfigurePiProxy, RemovePiProxy},
+		{"droid", droidProxyTestHome, droidSettingsFile, ConfigureDroidProxy, RemoveDroidProxy},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.home(t)
+			if err := util.WriteFile(tc.path(), "{}"); err != nil {
+				t.Fatal(err)
+			}
+			util.SetWriteFileOverride(func(string, string) error { return os.ErrPermission })
+			t.Cleanup(func() { util.SetWriteFileOverride(nil) })
+			if changed, _ := tc.configure(); changed {
+				t.Fatal("configure reported success when persistence failed")
+			}
+			util.SetWriteFileOverride(nil)
+			if changed, _ := tc.configure(); !changed {
+				t.Fatal("setup configure did not change")
+			}
+			util.SetWriteFileOverride(func(string, string) error { return os.ErrPermission })
+			if tc.remove() {
+				t.Fatal("remove reported success when persistence failed")
+			}
+		})
+	}
+}

--- a/internal/agents/proxy_protocol.go
+++ b/internal/agents/proxy_protocol.go
@@ -1,0 +1,22 @@
+package agents
+
+import "github.com/HoangP8/tokless/internal/util"
+
+// ProxyEndpointFor returns the headroom daemon endpoint tokless targets when it
+// wires an agent's config, applying the provider rule:
+//
+//   - OpenAI-compatible providers (codex, opencode, kilo, pi, droid) use the
+//     /v1 URL — their client appends /chat/completions, /responses, /models.
+//   - Anthropic-native providers (claude, omp) use the bare URL — their SDK
+//     appends /v1/messages itself.
+//
+// It returns "" for agents tokless does not wire through a config file.
+func ProxyEndpointFor(id string) string {
+	switch id {
+	case "codex", "opencode", "kilo", "pi", "droid":
+		return util.HeadroomProxyOpenAIURL()
+	case "claude", "omp":
+		return util.HeadroomProxyURL()
+	}
+	return ""
+}

--- a/internal/agents/proxy_protocol_test.go
+++ b/internal/agents/proxy_protocol_test.go
@@ -1,0 +1,28 @@
+package agents
+
+import "testing"
+
+// TestProxyEndpointForRouting pins the single wire-protocol rule: OpenAI-
+// compatible clients point at the daemon's /v1 surface, Anthropic-native
+// clients at the bare URL (their SDK appends /v1/messages itself), and anything
+// tokless does not wire through a config file has no endpoint.
+func TestProxyEndpointForRouting(t *testing.T) {
+	openai := proxyTestURL + "/v1"
+	bare := proxyTestURL
+
+	for _, id := range []string{"codex", "opencode", "kilo", "pi", "droid"} {
+		if got := ProxyEndpointFor(id); got != openai {
+			t.Errorf("ProxyEndpointFor(%q) = %q, want %q", id, got, openai)
+		}
+	}
+	for _, id := range []string{"claude", "omp"} {
+		if got := ProxyEndpointFor(id); got != bare {
+			t.Errorf("ProxyEndpointFor(%q) = %q, want bare %q", id, got, bare)
+		}
+	}
+	for _, id := range []string{"grok", "copilot", "cline", "cursor", "antigravity", "unknown"} {
+		if got := ProxyEndpointFor(id); got != "" {
+			t.Errorf("ProxyEndpointFor(%q) = %q, want empty", id, got)
+		}
+	}
+}

--- a/internal/agents/proxy_test.go
+++ b/internal/agents/proxy_test.go
@@ -1,0 +1,683 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+const proxyTestURL = "http://127.0.0.1:8787"
+
+func claudeProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+func TestClaudeProxyLifecycle(t *testing.T) {
+	claudeProxyTestHome(t)
+	settings := util.ClaudeCodePaths().Settings
+
+	changed, file := ConfigureClaudeProxy()
+	if !changed || file != settings {
+		t.Fatalf("ConfigureClaudeProxy = %v, %q", changed, file)
+	}
+	if !ClaudeProxyWired() {
+		t.Fatal("expected wired after configure")
+	}
+	if changed, _ := ConfigureClaudeProxy(); changed {
+		t.Fatal("second configure should be a no-op")
+	}
+	raw, ok := util.ReadFileSafe(settings)
+	if !ok || !strings.Contains(raw, `"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"`) {
+		t.Fatalf("settings missing proxy env:\n%s", raw)
+	}
+	if !RemoveClaudeProxy() {
+		t.Fatal("expected removal")
+	}
+	if ClaudeProxyWired() {
+		t.Fatal("expected unwired after remove")
+	}
+	if RemoveClaudeProxy() {
+		t.Fatal("second remove should be a no-op")
+	}
+}
+
+func TestClaudeProxyConfigurePreservesOtherEnvKeys(t *testing.T) {
+	claudeProxyTestHome(t)
+	settings := util.ClaudeCodePaths().Settings
+	seed := `{"env":{"ANTHROPIC_API_KEY":"sk-test","OTHER":"keep"}}`
+	if err := util.WriteFile(settings, seed); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _ := ConfigureClaudeProxy(); !changed {
+		t.Fatal("expected configure to write")
+	}
+	raw, _ := util.ReadFileSafe(settings)
+	if !strings.Contains(raw, `"sk-test"`) || !strings.Contains(raw, `"keep"`) {
+		t.Fatalf("other env keys lost:\n%s", raw)
+	}
+}
+
+func TestClaudeProxyDoesNotClobberUserValue(t *testing.T) {
+	claudeProxyTestHome(t)
+	settings := util.ClaudeCodePaths().Settings
+	seed := `{
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-test",
+    "ANTHROPIC_BASE_URL": "http://user.example:9999"
+  }
+}
+`
+	if err := util.WriteFile(settings, seed); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _ := ConfigureClaudeProxy(); changed {
+		t.Fatal("configure clobbered a user-set ANTHROPIC_BASE_URL")
+	}
+	if ClaudeProxyWired() {
+		t.Fatal("differing user value must not report wired")
+	}
+	if RemoveClaudeProxy() {
+		t.Fatal("remove must not delete a differing user value")
+	}
+	raw, _ := util.ReadFileSafe(settings)
+	if !strings.Contains(raw, "http://user.example:9999") || !strings.Contains(raw, "sk-test") {
+		t.Fatalf("user env was clobbered:\n%s", raw)
+	}
+}
+
+func TestClaudeProxyRefusesUnparseableConfig(t *testing.T) {
+	claudeProxyTestHome(t)
+	settings := util.ClaudeCodePaths().Settings
+	seed := `{"env": {"ANTHROPIC_API_KEY": "sk-test", `
+	if err := util.WriteFile(settings, seed); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _ := ConfigureClaudeProxy(); changed {
+		t.Fatal("configure must refuse an unparseable existing settings.json")
+	}
+	raw, _ := util.ReadFileSafe(settings)
+	if raw != seed {
+		t.Fatalf("unparseable config was clobbered:\n%s", raw)
+	}
+}
+
+func TestDetectProxyReadOnlyStates(t *testing.T) {
+	claudeProxyTestHome(t)
+	settings := util.ClaudeCodePaths().Settings
+	seed := `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8787"}}`
+	if err := util.WriteFile(settings, seed); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("claude"); got.State != ProxyStateManaged {
+		t.Fatalf("claude managed state = %s", got.State)
+	}
+	raw, _ := util.ReadFileSafe(settings)
+	if raw != seed {
+		t.Fatal("detection changed claude config")
+	}
+
+	if err := util.WriteFile(settings, `{"env":{"ANTHROPIC_BASE_URL":"http://user.example"}}`); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("claude"); got.State != ProxyStateForeignBYOK {
+		t.Fatalf("claude foreign state = %s", got.State)
+	}
+	if err := util.WriteFile(settings, `{`); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("claude"); got.State != ProxyStateUnreadable {
+		t.Fatalf("claude unreadable state = %s", got.State)
+	}
+	if err := os.Remove(settings); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("claude"); got.State != ProxyStateAbsent {
+		t.Fatalf("claude absent state = %s", got.State)
+	}
+}
+
+func TestDetectProxyUnreadableConfigIsNotAbsentAndDoesNotMutate(t *testing.T) {
+	claudeProxyTestHome(t)
+	path := util.ClaudeCodePaths().Settings
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("claude"); got.State != ProxyStateUnreadable {
+		t.Fatalf("directory at config path = %s, want %s", got.State, ProxyStateUnreadable)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("detector mutated unreadable config path: %v", err)
+	}
+}
+
+func TestDetectProxyConservativeStates(t *testing.T) {
+	if got := DetectProxy("grok"); got.State != ProxyStateUnknown {
+		t.Fatalf("manual absent state = %s", got.State)
+	}
+	t.Setenv("GROK_MODELS_BASE_URL", util.HeadroomProxyOpenAIURL())
+	if got := DetectProxy("grok"); got.State != ProxyStateUnknown || !strings.Contains(got.Detail, "ownership unknown") {
+		t.Fatalf("manual equality = %+v", got)
+	}
+	t.Setenv("GROK_MODELS_BASE_URL", "http://user.example")
+	if got := DetectProxy("grok"); got.State != ProxyStateForeignBYOK {
+		t.Fatalf("manual foreign state = %s", got.State)
+	}
+	if got := DetectProxy("cline"); got.State != ProxyStateUnknown {
+		t.Fatalf("cline state = %s", got.State)
+	}
+	if got := DetectProxy("antigravity"); got.State != ProxyStateUnknown || got.Capability.WireKind != ProxyWireMCPOnly {
+		t.Fatalf("antigravity = %+v", got)
+	}
+	if got := DetectProxy("arbitrary"); got.State != ProxyStateUnknown || got.Capability.ID != "arbitrary" {
+		t.Fatalf("unsupported = %+v", got)
+	}
+}
+
+func TestDetectOmpMalformedIsUnknown(t *testing.T) {
+	ompProxyTestHome(t)
+	if err := util.WriteFile(ompModelsFile(), "providers:\n  anthropic:\n    baseUrl: [\n"); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectProxy("omp")
+	if got.State != ProxyStateUnknown {
+		t.Fatalf("malformed OMP state = %s", got.State)
+	}
+	if strings.Contains(got.Detail, "http://") || strings.Contains(got.Detail, "user.example") {
+		t.Fatalf("OMP detail contains endpoint: %q", got.Detail)
+	}
+	if got.State == ProxyStateForeignBYOK || got.State == ProxyStateUnconfigured {
+		t.Fatal("malformed OMP was classified as a route")
+	}
+}
+
+func TestDetectOmpManagedEndpointTextRemainsUnknown(t *testing.T) {
+	ompProxyTestHome(t)
+	raw := `providers:
+  anthropic:
+    baseUrl: http://127.0.0.1:8787
+    broken: [
+`
+	if err := util.WriteFile(ompModelsFile(), raw); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectProxy("omp")
+	if got.State != ProxyStateUnknown {
+		t.Fatalf("OMP managed endpoint text state = %s", got.State)
+	}
+	if strings.Contains(got.Detail, "http://") || strings.Contains(got.Detail, "127.0.0.1") {
+		t.Fatalf("OMP detail contains endpoint: %q", got.Detail)
+	}
+}
+
+func TestDetectCodexReservedConflict(t *testing.T) {
+	codexProxyTestHome(t)
+	path := util.CodexPathsResolved().Config
+	if err := util.WriteFile(path, `model_provider = "headroom"
+openai_base_url = "http://user.example"
+[model_providers.headroom]
+base_url = "http://user.example"
+`); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("codex"); got.State != ProxyStateUnknown {
+		t.Fatalf("codex existing state = %s", got.State)
+	}
+	if err := util.WriteFile(path, `# model_provider = "headroom"
+# [model_providers.headroom]
+`); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("codex"); got.State == ProxyStateForeignBYOK {
+		t.Fatal("codex comment substring classified as foreign")
+	}
+}
+
+func TestDetectCodexRequiresExactManagedProviderBlock(t *testing.T) {
+	codexProxyTestHome(t)
+	path := util.CodexPathsResolved().Config
+	endpoint := ProxyEndpointFor("codex")
+	cases := []struct {
+		name  string
+		block string
+		state ProxyConfigState
+	}{
+		{name: "foreign block", block: `
+[model_providers.headroom]
+name = "Foreign proxy"
+base_url = "` + endpoint + `"
+supports_websockets = true
+`, state: ProxyStateUnknown},
+		{name: "exact block", block: `
+[model_providers.headroom]
+supports_websockets = true # text [model_providers.headroom] name = "wrong"
+name = "Headroom persistent proxy"
+base_url = "` + endpoint + `#not-a-comment"
+`, state: ProxyStateUnknown},
+		{name: "exact desired block", block: `
+[model_providers.headroom]
+name = "Headroom persistent proxy" # foreign text [model_providers.headroom]
+base_url = "` + endpoint + `"
+supports_websockets = true
+`, state: ProxyStateUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := `model_provider = "headroom"
+openai_base_url = "` + endpoint + `"
+` + tc.block
+			if err := util.WriteFile(path, raw); err != nil {
+				t.Fatal(err)
+			}
+			if got := DetectProxy("codex"); got.State != tc.state {
+				t.Fatalf("codex state = %s, want %s", got.State, tc.state)
+			}
+		})
+	}
+}
+
+func TestDetectCodexManagedEndpointTextRemainsUnknown(t *testing.T) {
+	codexProxyTestHome(t)
+	path := util.CodexPathsResolved().Config
+	endpoint := ProxyEndpointFor("codex")
+	raw := `malformed = [
+model_provider = "headroom"
+openai_base_url = "` + endpoint + `"
+`
+	if err := util.WriteFile(path, raw); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectProxy("codex")
+	if got.State != ProxyStateUnknown {
+		t.Fatalf("codex managed endpoint text state = %s", got.State)
+	}
+	if strings.Contains(got.Detail, endpoint) {
+		t.Fatalf("codex detail contains endpoint: %q", got.Detail)
+	}
+}
+
+func TestDetectCodexIgnoresCommentedRootRoute(t *testing.T) {
+	codexProxyTestHome(t)
+	path := util.CodexPathsResolved().Config
+	endpoint := ProxyEndpointFor("codex")
+	raw := `# model_provider = "headroom"
+# openai_base_url = "` + endpoint + `"
+[model_providers.headroom]
+name = "Headroom persistent proxy"
+base_url = "` + endpoint + `"
+supports_websockets = true
+`
+	if err := util.WriteFile(path, raw); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProxy("codex"); got.State != ProxyStateUnknown {
+		t.Fatalf("codex state = %s, want %s", got.State, ProxyStateUnknown)
+	}
+}
+
+func codexProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("CODEX_HOME", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+func codexProxySeed(foreignBlock bool) string {
+	if foreignBlock {
+		return `[model_providers.headroom]
+base_url = "http://user.example:9999/v1"
+
+[features]
+use_system_prompt_optimizer = true
+`
+	}
+	return `[features]
+use_system_prompt_optimizer = true
+`
+}
+
+func TestCodexProxyScenarios(t *testing.T) {
+	cases := []proxyScenario{
+		{name: "inject writes root keys and provider table", seed: codexProxySeed(false),
+			wantChange: true, wantWired: true, wantContains: []string{
+				`model_provider = "headroom"`,
+				`openai_base_url = "http://127.0.0.1:8787/v1"`,
+				"[model_providers.headroom]",
+				`name = "Headroom persistent proxy"`,
+				`base_url = "http://127.0.0.1:8787/v1"`,
+				"supports_websockets = true",
+				"use_system_prompt_optimizer = true",
+			}},
+		{name: "second inject idempotent", seed: codexProxySeed(false), preConfigure: true,
+			wantChange: false, wantWired: true},
+		{name: "refuses differing root keys", seed: `model_provider = "openai"
+openai_base_url = "http://user.example:9999/v1"
+`,
+			wantChange: false, wantWired: false, keepContains: []string{`"openai"`, "user.example"}},
+		{name: "refuses differing provider block", seed: codexProxySeed(true),
+			wantChange: false, wantWired: false, keepContains: []string{"user.example"}},
+		{name: "remove deletes only matching", seed: codexProxySeed(false), preConfigure: true,
+			remove: true, wantRemoved: true, wantWired: false},
+		{name: "remove leaves differing value", seed: `model_provider = "openai"
+openai_base_url = "http://user.example:9999/v1"
+`,
+			remove: true, wantRemoved: false, wantWired: false, keepContains: []string{"user.example"}},
+		{name: "absent file not created", seed: "", absent: true,
+			wantChange: false, wantWired: false},
+	}
+	runProxyScenarios(t, cases, codexProxyTestHome,
+		ConfigureCodexProxy, RemoveCodexProxy, CodexProxyWired, func() string { return util.CodexPathsResolved().Config })
+}
+
+func openCodeProxySeed(foreign bool) string {
+	if foreign {
+		return `{"$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "headroom": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "User Proxy",
+      "options": {"baseURL": "http://user.example:9999/v1"},
+      "models": {}
+    }
+  }
+}
+`
+	}
+	return `{"$schema": "https://opencode.ai/config.json", "theme": "dark"}
+`
+}
+
+func opencodeProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+func TestOpenCodeProxyScenarios(t *testing.T) {
+	cases := []proxyScenario{
+		{name: "inject writes headroom provider", seed: openCodeProxySeed(false),
+			wantChange: true, wantWired: true, wantContains: []string{
+				`"headroom"`,
+				`"npm": "@ai-sdk/openai-compatible"`,
+				`"name": "Headroom Proxy"`,
+				`"baseURL": "http://127.0.0.1:8787/v1"`,
+				`"gpt-4.1"`,
+				`"context": 1048576`,
+				`"theme": "dark"`,
+			}},
+		{name: "second inject idempotent", seed: openCodeProxySeed(false), preConfigure: true,
+			wantChange: false, wantWired: true},
+		{name: "refuses differing provider entry", seed: openCodeProxySeed(true),
+			wantChange: false, wantWired: false, keepContains: []string{"User Proxy", "user.example"}},
+		{name: "refuses non-map provider", seed: `{"provider": "junk"}
+`,
+			wantChange: false, wantWired: false, keepContains: []string{`"junk"`}},
+		{name: "remove deletes only matching", seed: openCodeProxySeed(false), preConfigure: true,
+			remove: true, wantRemoved: true, wantWired: false},
+		{name: "remove leaves differing value", seed: openCodeProxySeed(true),
+			remove: true, wantRemoved: false, wantWired: false, keepContains: []string{"User Proxy", "user.example"}},
+		{name: "absent file not created", seed: "", absent: true,
+			wantChange: false, wantWired: false},
+	}
+	runProxyScenarios(t, cases, opencodeProxyTestHome,
+		ConfigureOpenCodeProxy, RemoveOpenCodeProxy, OpenCodeProxyWired, func() string { return util.OpenCodePathsResolved().Config })
+}
+
+func ompProxyTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("PI_CONFIG_DIR", "")
+	t.Setenv("OMP_PROFILE", "")
+	t.Setenv("PI_PROFILE", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+}
+
+func ompProxySeed(foreign bool) string {
+	if foreign {
+		return `providers:
+  anthropic:
+    baseUrl: http://user.example:9999
+models:
+  claude-sonnet:
+    id: claude-sonnet
+`
+	}
+	return `models:
+  claude-sonnet:
+    id: claude-sonnet
+`
+}
+
+func TestOmpProxyScenarios(t *testing.T) {
+	cases := []proxyScenario{
+		{name: "inject writes anthropic baseUrl", seed: ompProxySeed(false),
+			wantChange: true, wantWired: true, wantContains: []string{
+				"providers:", "  anthropic:", "    baseUrl: http://127.0.0.1:8787",
+				"claude-sonnet",
+			}},
+		{name: "second inject idempotent", seed: ompProxySeed(false), preConfigure: true,
+			wantChange: false, wantWired: true},
+		{name: "refuses differing baseUrl", seed: ompProxySeed(true),
+			wantChange: false, wantWired: false, keepContains: []string{"user.example", "claude-sonnet"}},
+		{name: "remove deletes only matching", seed: ompProxySeed(false), preConfigure: true,
+			remove: true, wantRemoved: true, wantWired: false},
+		{name: "remove leaves differing value", seed: ompProxySeed(true),
+			remove: true, wantRemoved: false, wantWired: false, keepContains: []string{"user.example", "claude-sonnet"}},
+		{name: "absent file not created", seed: "", absent: true,
+			wantChange: false, wantWired: false},
+	}
+	runProxyScenarios(t, cases, ompProxyTestHome,
+		ConfigureOmpProxy, RemoveOmpProxy, OmpProxyWired, func() string { return ompModelsFile() })
+}
+
+func TestOmpProxyConfigureDoesNotInsertUnderOpenAISibling(t *testing.T) {
+	ompProxyTestHome(t)
+	raw := `providers:
+  anthropic:
+    name: Anthropic
+  openai:
+    baseUrl: https://api.openai.com/v1
+models:
+  claude-sonnet:
+    id: claude-sonnet
+`
+	if err := util.WriteFile(ompModelsFile(), raw); err != nil {
+		t.Fatal(err)
+	}
+	ConfigureOmpProxy()
+	got, ok := util.ReadFileSafe(ompModelsFile())
+	if !ok {
+		t.Fatal("models.yml missing")
+	}
+	if !strings.Contains(got, "  anthropic:\n    name: Anthropic\n    baseUrl: "+proxyTestURL) {
+		t.Fatalf("baseUrl not inserted under anthropic:\n%s", got)
+	}
+	if strings.Contains(got, "    baseUrl: "+proxyTestURL+"\nmodels:") {
+		t.Fatalf("baseUrl inserted outside anthropic mapping:\n%s", got)
+	}
+	if !strings.Contains(got, "  openai:\n    baseUrl: https://api.openai.com/v1") {
+		t.Fatalf("openai sibling changed:\n%s", got)
+	}
+}
+
+func TestOmpProxyRemoveDoesNotDeleteOpenAISiblingBaseURL(t *testing.T) {
+	ompProxyTestHome(t)
+	raw := `providers:
+  anthropic:
+    name: Anthropic
+  openai:
+    baseUrl: https://api.openai.com/v1
+models:
+  claude-sonnet:
+    id: claude-sonnet
+`
+	if err := util.WriteFile(ompModelsFile(), raw); err != nil {
+		t.Fatal(err)
+	}
+	if RemoveOmpProxy() {
+		t.Fatal("remove must not delete openai sibling baseUrl")
+	}
+	if OmpProxyWired() {
+		t.Fatal("anthropic without baseUrl must not report wired")
+	}
+	got, ok := util.ReadFileSafe(ompModelsFile())
+	if !ok {
+		t.Fatal("models.yml missing")
+	}
+	if got != raw {
+		t.Fatalf("openai sibling changed:\n%s", got)
+	}
+}
+
+func TestOmpProxyIgnoresNestedAnthropicProvider(t *testing.T) {
+	ompProxyTestHome(t)
+	raw := `providers:
+  openai:
+    models:
+      anthropic:
+        baseUrl: http://nested.example:9999
+models:
+  claude-sonnet:
+    id: claude-sonnet
+`
+	if err := util.WriteFile(ompModelsFile(), raw); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _ := ConfigureOmpProxy(); !changed {
+		t.Fatal("expected direct anthropic provider insertion")
+	}
+	got, _ := util.ReadFileSafe(ompModelsFile())
+	if !strings.Contains(got, "  anthropic:\n    baseUrl: "+proxyTestURL) {
+		t.Fatalf("direct anthropic provider missing:\n%s", got)
+	}
+	if !strings.Contains(got, "      anthropic:\n        baseUrl: http://nested.example:9999") {
+		t.Fatalf("nested anthropic sibling changed:\n%s", got)
+	}
+}
+
+func TestOmpProxyRemoveReportsWriteFailure(t *testing.T) {
+	ompProxyTestHome(t)
+	if err := util.WriteFile(ompModelsFile(), ompProxySeed(false)); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _ := ConfigureOmpProxy(); !changed {
+		t.Fatal("prereq configure did not change")
+	}
+	oldWrite := ompWriteFile
+	ompWriteFile = func(string, string) error { return os.ErrPermission }
+	t.Cleanup(func() { ompWriteFile = oldWrite })
+	if RemoveOmpProxy() {
+		t.Fatal("remove reported success after write failure")
+	}
+	if !OmpProxyWired() {
+		t.Fatal("proxy wiring changed despite write failure")
+	}
+}
+
+// TestOmpProxyHonorsPiCodingAgentDir verifies models.yml follows the relocated
+// omp agent dir.
+func TestOmpProxyHonorsPiCodingAgentDir(t *testing.T) {
+	home := t.TempDir()
+	relocated := filepath.Join(home, "custom-agent")
+	util.SetHomeOverride(filepath.Join(home, "fake-home"))
+	t.Setenv("PI_CODING_AGENT_DIR", relocated)
+	t.Setenv("PI_CONFIG_DIR", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	if err := util.WriteFile(ompModelsFile(), "models:\n  x: y\n"); err != nil {
+		t.Fatal(err)
+	}
+	changed, file := ConfigureOmpProxy()
+	if !changed || file != filepath.Join(relocated, "models.yml") {
+		t.Fatalf("ConfigureOmpProxy = %v, %q", changed, file)
+	}
+	if !OmpProxyWired() {
+		t.Fatal("expected wired in relocated dir")
+	}
+}
+
+// proxyScenario is one behavior check for a proxy writer trio. seed "" means
+// "no config file present" unless absent is set; absent marks expectation that
+// the file must not be created.
+type proxyScenario struct {
+	name         string
+	seed         string
+	absent       bool
+	preConfigure bool
+	remove       bool
+	wantChange   bool
+	wantRemoved  bool
+	wantWired    bool
+	wantContains []string
+	keepContains []string
+}
+
+func runProxyScenarios(t *testing.T, cases []proxyScenario,
+	home func(t *testing.T),
+	configure func() (bool, string),
+	remove func() bool,
+	wired func() bool,
+	file func() string,
+) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			home(t)
+			path := file()
+			if c.seed != "" {
+				if err := util.WriteFile(path, c.seed); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if c.preConfigure {
+				if changed, _ := configure(); !changed {
+					t.Fatal("prereq configure did not change")
+				}
+			}
+			if c.remove {
+				if got := remove(); got != c.wantRemoved {
+					t.Fatalf("remove = %v, want %v", got, c.wantRemoved)
+				}
+			} else {
+				changed, _ := configure()
+				if changed != c.wantChange {
+					t.Fatalf("configure changed = %v, want %v", changed, c.wantChange)
+				}
+				if c.absent && util.Exists(path) {
+					t.Fatalf("configure created absent file %s", path)
+				}
+			}
+			if got := wired(); got != c.wantWired {
+				t.Fatalf("wired = %v, want %v", got, c.wantWired)
+			}
+			if len(c.wantContains) > 0 {
+				raw, ok := util.ReadFileSafe(path)
+				if !ok {
+					t.Fatalf("cannot read %s", path)
+				}
+				for _, want := range c.wantContains {
+					if !strings.Contains(raw, want) {
+						t.Fatalf("missing %q in:\n%s", want, raw)
+					}
+				}
+			}
+			if len(c.keepContains) > 0 {
+				raw, _ := util.ReadFileSafe(path)
+				for _, want := range c.keepContains {
+					if !strings.Contains(raw, want) {
+						t.Fatalf("foreign value %q lost:\n%s", want, raw)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/commands/disable.go
+++ b/internal/commands/disable.go
@@ -64,7 +64,9 @@ func runPurge() int {
 			}
 		}
 	}
-	_ = os.RemoveAll(util.HeadroomPathsResolved().Root)
+	if err := os.RemoveAll(util.HeadroomPathsResolved().Root); err != nil {
+		return n + 1
+	}
 	return n
 }
 
@@ -79,6 +81,9 @@ func disableImpl(opts InitOptions, removeTools bool, verb string) int {
 		}
 	}
 	if len(detected) == 0 {
+		if removeTools && !opts.DryRun {
+			_ = purgeBinaries(opts)
+		}
 		util.L.Raw("  " + util.C.Gray("nothing wired."))
 		util.L.Raw("")
 		return 0

--- a/internal/commands/disable.go
+++ b/internal/commands/disable.go
@@ -64,6 +64,7 @@ func runPurge() int {
 			}
 		}
 	}
+	_ = os.RemoveAll(util.HeadroomPathsResolved().Root)
 	return n
 }
 

--- a/internal/commands/doctor_probe.go
+++ b/internal/commands/doctor_probe.go
@@ -163,9 +163,22 @@ func unwrapRunMcp(command string, args []string) (string, []string) {
 	if base != "tokless" && base != "tokless.exe" {
 		return command, args
 	}
-	// run-mcp --agent <id> <cmd> [args...]
-	if len(args) >= 4 && args[0] == "run-mcp" && args[1] == "--agent" {
-		return args[3], append([]string(nil), args[4:]...)
+	if len(args) == 0 || args[0] != "run-mcp" {
+		return command, args
+	}
+	args = args[1:]
+	for len(args) > 0 {
+		switch args[0] {
+		case "--agent", "--workspace", "--tool":
+			if len(args) < 2 || args[1] == "" || strings.HasPrefix(args[1], "--") {
+				return command, args
+			}
+			args = args[2:]
+		case "--context-mode":
+			args = args[1:]
+		default:
+			return args[0], append([]string(nil), args[1:]...)
+		}
 	}
 	return command, args
 }

--- a/internal/commands/doctor_probe_test.go
+++ b/internal/commands/doctor_probe_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -144,6 +145,13 @@ func TestUnwrapRunMcp(t *testing.T) {
 	cmd, args = unwrapRunMcp("codegraph", []string{"serve", "--mcp"})
 	if cmd != "codegraph" || len(args) != 2 {
 		t.Fatalf("passthrough = %q %v", cmd, args)
+	}
+}
+
+func TestUnwrapRunMcpHeadroom(t *testing.T) {
+	command, args := unwrapRunMcp("tokless", []string{"run-mcp", "--tool", "headroom", "/managed/headroom", "mcp", "serve"})
+	if command != "/managed/headroom" || !reflect.DeepEqual(args, []string{"mcp", "serve"}) {
+		t.Fatalf("unwrap = %q %v", command, args)
 	}
 }
 

--- a/internal/commands/mcp_proxy.go
+++ b/internal/commands/mcp_proxy.go
@@ -16,27 +16,27 @@ import (
 )
 
 // runMcpProxy spawns the MCP server as a child and proxies stdio.
-func runMcpProxy(agent, path string, argv, env []string, filterContextMode bool) int {
-	return runMcpProxyAfterStart(agent, path, argv, env, filterContextMode, nil)
+func runMcpProxy(agent, path string, argv, env []string, tool string) int {
+	return runMcpProxyAfterStart(agent, path, argv, env, tool, nil)
 }
 
-func runMcpProxyIO(agent, path string, argv, env []string, input io.Reader, output, stderr io.Writer, filterContextMode bool) int {
-	return runMcpProxyIOAfterStart(agent, path, argv, env, input, output, stderr, filterContextMode, nil)
+func runMcpProxyIO(agent, path string, argv, env []string, input io.Reader, output, stderr io.Writer, tool string) int {
+	return runMcpProxyIOAfterStart(agent, path, argv, env, input, output, stderr, tool, nil)
 }
 
-func runMcpProxyAfterStart(agent, path string, argv, env []string, filterContextMode bool, afterStart func()) int {
-	return runMcpProxyIOAfterStart(agent, path, argv, env, os.Stdin, os.Stdout, os.Stderr, filterContextMode, afterStart)
+func runMcpProxyAfterStart(agent, path string, argv, env []string, tool string, afterStart func()) int {
+	return runMcpProxyIOAfterStart(agent, path, argv, env, os.Stdin, os.Stdout, os.Stderr, tool, afterStart)
 }
 
-func runMcpProxyIOAfterStart(agent, path string, argv, env []string, input io.Reader, output, stderr io.Writer, filterContextMode bool, afterStart func()) int {
+func runMcpProxyIOAfterStart(agent, path string, argv, env []string, input io.Reader, output, stderr io.Writer, tool string, afterStart func()) int {
 	exe, args := resolveMcpCommand(path, argv)
 	cmd := exec.Command(exe, args...)
 	cmd.Env = mcpChildEnv(env)
 	cmd.Stderr = stderr
-	if filterContextMode {
+	if allowed := mcpToolPolicies[tool]; len(allowed) > 0 {
 		if afterStart != nil {
 		}
-		return runBoundedContextModeProxy(cmd, input, output)
+		return runBoundedMcpProxy(cmd, input, output, allowed)
 	}
 	cmd.Stdin = input
 	stdout, err := cmd.StdoutPipe()
@@ -64,9 +64,13 @@ var contextModeTools = []string{
 	"ctx_fetch_and_index",
 }
 
-// runBoundedContextModeProxy forwards MCP traffic unchanged except tools/list
-// responses, whose tools are reduced to contextModeTools.
-func runBoundedContextModeProxy(cmd *exec.Cmd, input io.Reader, output io.Writer) int {
+var mcpToolPolicies = map[string][]string{
+	"context-mode": contextModeTools,
+	"headroom":     {"headroom_compress", "headroom_retrieve"},
+}
+
+// runBoundedMcpProxy forwards MCP traffic unchanged except an explicit tool allowlist.
+func runBoundedMcpProxy(cmd *exec.Cmd, input io.Reader, output io.Writer, allowed []string) int {
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return 1
@@ -83,9 +87,9 @@ func runBoundedContextModeProxy(cmd *exec.Cmd, input io.Reader, output io.Writer
 	inputDone := make(chan error, 1)
 	go func() {
 		defer stdin.Close()
-		inputDone <- scanMcpInput(input, stdin, lockedOutput, listIDs)
+		inputDone <- scanMcpInput(input, stdin, lockedOutput, listIDs, allowed)
 	}()
-	outputErr := scanMcpOutput(stdout, lockedOutput, listIDs)
+	outputErr := scanMcpOutput(stdout, lockedOutput, listIDs, allowed)
 	_ = stdin.Close() // Upstream EOF must not wait for a client that keeps stdin open.
 	code := waitExit(cmd)
 	if outputErr != nil || code != 0 {
@@ -132,7 +136,7 @@ const (
 	mcpContentLength
 )
 
-func scanMcpInput(input io.Reader, upstream, output io.Writer, listIDs *mcpRequestIDs) error {
+func scanMcpInput(input io.Reader, upstream, output io.Writer, listIDs *mcpRequestIDs, allowed []string) error {
 	reader := bufio.NewReader(input)
 	for {
 		line, framing, err := readMCPMessage(reader)
@@ -162,7 +166,7 @@ func scanMcpInput(input io.Reader, upstream, output io.Writer, listIDs *mcpReque
 				listIDs.mu.Unlock()
 			}
 		}
-		if request.Method == "tools/call" && !isContextModeTool(request.Params.Name) {
+		if request.Method == "tools/call" && !isAllowedMcpTool(request.Params.Name, allowed) {
 			if err := writeMCPMessage(output, framing, mcpToolDeniedResponse(request.ID, request.Params.Name)); err != nil {
 				return err
 			}
@@ -174,7 +178,7 @@ func scanMcpInput(input io.Reader, upstream, output io.Writer, listIDs *mcpReque
 	}
 }
 
-func scanMcpOutput(upstream io.Reader, output io.Writer, listIDs *mcpRequestIDs) error {
+func scanMcpOutput(upstream io.Reader, output io.Writer, listIDs *mcpRequestIDs, allowed []string) error {
 	reader := bufio.NewReader(upstream)
 	for {
 		line, framing, err := readMCPMessage(reader)
@@ -184,8 +188,8 @@ func scanMcpOutput(upstream io.Reader, output io.Writer, listIDs *mcpRequestIDs)
 		if err != nil {
 			return err
 		}
-		if filterContextModeTools(line, listIDs) {
-			line = filterContextModeToolsResponse(line)
+		if filterMcpTools(line, listIDs) {
+			line = filterMcpToolsResponse(line, allowed)
 		}
 		if err := writeMCPMessage(output, framing, line); err != nil {
 			return err
@@ -193,7 +197,7 @@ func scanMcpOutput(upstream io.Reader, output io.Writer, listIDs *mcpRequestIDs)
 	}
 }
 
-func filterContextModeTools(line []byte, listIDs *mcpRequestIDs) bool {
+func filterMcpTools(line []byte, listIDs *mcpRequestIDs) bool {
 	var response map[string]json.RawMessage
 	if json.Unmarshal(line, &response) != nil {
 		return false
@@ -268,8 +272,8 @@ func canonicalMCPNumber(number string) (string, bool) {
 	return "number:" + sign + number + "e" + strconv.Itoa(exponent), true
 }
 
-func isContextModeTool(name string) bool {
-	for _, allowed := range contextModeTools {
+func isAllowedMcpTool(name string, allowedTools []string) bool {
+	for _, allowed := range allowedTools {
 		if name == allowed {
 			return true
 		}
@@ -378,7 +382,7 @@ func writeMCPMessageUnlocked(writer io.Writer, framing mcpFraming, message []byt
 	return err
 }
 
-func filterContextModeToolsResponse(line []byte) []byte {
+func filterMcpToolsResponse(line []byte, allowedTools []string) []byte {
 	var response map[string]json.RawMessage
 	if json.Unmarshal(line, &response) != nil {
 		return line
@@ -400,8 +404,8 @@ func filterContextModeToolsResponse(line []byte) []byte {
 			byName[item.Name] = tool
 		}
 	}
-	filtered := make([]json.RawMessage, 0, len(contextModeTools))
-	for _, name := range contextModeTools {
+	filtered := make([]json.RawMessage, 0, len(allowedTools))
+	for _, name := range allowedTools {
 		if tool, ok := byName[name]; ok {
 			filtered = append(filtered, tool)
 		}

--- a/internal/commands/mcp_proxy.go
+++ b/internal/commands/mcp_proxy.go
@@ -34,9 +34,7 @@ func runMcpProxyIOAfterStart(agent, path string, argv, env []string, input io.Re
 	cmd.Env = mcpChildEnv(env)
 	cmd.Stderr = stderr
 	if allowed := mcpToolPolicies[tool]; len(allowed) > 0 {
-		if afterStart != nil {
-		}
-		return runBoundedMcpProxy(cmd, input, output, allowed)
+		return runBoundedMcpProxy(cmd, input, output, allowed, afterStart)
 	}
 	cmd.Stdin = input
 	stdout, err := cmd.StdoutPipe()
@@ -70,7 +68,7 @@ var mcpToolPolicies = map[string][]string{
 }
 
 // runBoundedMcpProxy forwards MCP traffic unchanged except an explicit tool allowlist.
-func runBoundedMcpProxy(cmd *exec.Cmd, input io.Reader, output io.Writer, allowed []string) int {
+func runBoundedMcpProxy(cmd *exec.Cmd, input io.Reader, output io.Writer, allowed []string, afterStart func()) int {
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return 1
@@ -81,6 +79,9 @@ func runBoundedMcpProxy(cmd *exec.Cmd, input io.Reader, output io.Writer, allowe
 	}
 	if err := cmd.Start(); err != nil {
 		return 1
+	}
+	if afterStart != nil {
+		afterStart()
 	}
 	listIDs := &mcpRequestIDs{ids: map[string]bool{}}
 	lockedOutput := &mcpLockedWriter{writer: output}
@@ -167,8 +168,10 @@ func scanMcpInput(input io.Reader, upstream, output io.Writer, listIDs *mcpReque
 			}
 		}
 		if request.Method == "tools/call" && !isAllowedMcpTool(request.Params.Name, allowed) {
-			if err := writeMCPMessage(output, framing, mcpToolDeniedResponse(request.ID, request.Params.Name)); err != nil {
-				return err
+			if _, ok := canonicalMCPID(request.ID); ok {
+				if err := writeMCPMessage(output, framing, mcpToolDeniedResponse(request.ID, request.Params.Name)); err != nil {
+					return err
+				}
 			}
 			continue
 		}

--- a/internal/commands/mcp_proxy_test.go
+++ b/internal/commands/mcp_proxy_test.go
@@ -120,7 +120,7 @@ func main() {
 	}
 	input := bytes.NewBufferString("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"ctx_search\"}}\n")
 	var output bytes.Buffer
-	if code := runMcpProxyIO("", "go", []string{"go", "run", upstream}, nil, input, &output, io.Discard, true); code != 0 {
+	if code := runMcpProxyIO("", "go", []string{"go", "run", upstream}, nil, input, &output, io.Discard, "context-mode"); code != 0 {
 		t.Fatalf("proxy exit code = %d", code)
 	}
 	var responses []map[string]any
@@ -150,10 +150,57 @@ func main() {
 	}
 }
 
+func TestHeadroomPolicyFiltersAndRejectsHiddenTools(t *testing.T) {
+	allowed := mcpToolPolicies["headroom"]
+	ids := &mcpRequestIDs{ids: map[string]bool{}}
+	var upstream, output bytes.Buffer
+	input := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"headroom_compress"}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"headroom_stats"}}`,
+	}, "\n") + "\n"
+	if err := scanMcpInput(strings.NewReader(input), &upstream, &output, ids, allowed); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(upstream.String(), "tools/call"); got != 1 || strings.Contains(upstream.String(), "headroom_stats") {
+		t.Fatalf("hidden Headroom call reached upstream: %q", upstream.String())
+	}
+	if !strings.Contains(output.String(), `"id":3`) || !strings.Contains(output.String(), `"code":-32601`) || !strings.Contains(output.String(), `tool \"headroom_stats\" is not available`) {
+		t.Fatalf("unexpected denied response: %q", output.String())
+	}
+
+	output.Reset()
+	response := `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"headroom_compress"},{"name":"headroom_stats"},{"name":"headroom_retrieve"},{"name":"headroom_read"}]}}` + "\n"
+	if err := scanMcpOutput(strings.NewReader(response), &output, ids, allowed); err != nil {
+		t.Fatal(err)
+	}
+	got := output.String()
+	if strings.Contains(got, "headroom_stats") || strings.Contains(got, "headroom_read") || !strings.Contains(got, "headroom_compress") || !strings.Contains(got, "headroom_retrieve") {
+		t.Fatalf("Headroom list not correctly filtered: %q", got)
+	}
+}
+
+func TestUnboundedProxyPassesThroughTools(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh fixture")
+	}
+	script := filepath.Join(t.TempDir(), "upstream")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nread line\nprintf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"headroom_stats\"}]}}'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if code := runMcpProxyIO("", script, []string{script}, nil, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`+"\n"), &output, io.Discard, ""); code != 0 {
+		t.Fatalf("proxy exit code = %d", code)
+	}
+	if !strings.Contains(output.String(), "headroom_stats") {
+		t.Fatalf("unbounded proxy filtered upstream tools: %q", output.String())
+	}
+}
+
 func TestScanMcpInputSupportsLargeNDJSONMessage(t *testing.T) {
 	message := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ctx_search","arguments":{"query":"` + strings.Repeat("x", 70<<10) + `"}}}`
 	var upstream, output bytes.Buffer
-	if err := scanMcpInput(strings.NewReader(message+"\n"), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}); err != nil {
+	if err := scanMcpInput(strings.NewReader(message+"\n"), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.TrimSpace(upstream.String()); got != message {
@@ -164,7 +211,7 @@ func TestScanMcpInputSupportsLargeNDJSONMessage(t *testing.T) {
 func TestScanMcpInputRejectsHiddenToolLocally(t *testing.T) {
 	request := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"hidden"}}`
 	var upstream, output bytes.Buffer
-	if err := scanMcpInput(strings.NewReader(request+"\n"), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}); err != nil {
+	if err := scanMcpInput(strings.NewReader(request+"\n"), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	if upstream.Len() != 0 {
@@ -187,7 +234,7 @@ func TestScanMcpInputRejectsHiddenToolLocally(t *testing.T) {
 func TestScanMcpInputRejectsBatchFailClosed(t *testing.T) {
 	batch := `[{"jsonrpc":"2.0","id":1,"method":"tools/list"},{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hidden"}}]`
 	var upstream, output bytes.Buffer
-	if err := scanMcpInput(strings.NewReader(batch+"\n"), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}); err != nil {
+	if err := scanMcpInput(strings.NewReader(batch+"\n"), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	if upstream.Len() != 0 {
@@ -212,14 +259,14 @@ func TestToolsListIDIsCanonicalAndRemovedAfterResponse(t *testing.T) {
 	ids := &mcpRequestIDs{ids: map[string]bool{}}
 	var upstream, discarded bytes.Buffer
 	input := "{\"jsonrpc\":\"2.0\",\"id\": 1,\"method\":\"tools/list\"}\n"
-	if err := scanMcpInput(strings.NewReader(input), &upstream, &discarded, ids); err != nil {
+	if err := scanMcpInput(strings.NewReader(input), &upstream, &discarded, ids, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	response := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"hidden"}]}}`)
-	if !filterContextModeTools(response, ids) {
+	if !filterMcpTools(response, ids) {
 		t.Fatal("equivalent request/response IDs did not correlate")
 	}
-	if filterContextModeTools(response, ids) {
+	if filterMcpTools(response, ids) {
 		t.Fatal("request ID was reused after correlated response")
 	}
 }
@@ -238,11 +285,11 @@ func TestToolsListIDsCorrelateSemanticJSONValues(t *testing.T) {
 			ids := &mcpRequestIDs{ids: map[string]bool{}}
 			input := `{"jsonrpc":"2.0","id":` + tt.request + `,"method":"tools/list"}` + "\n"
 			var upstream, discarded bytes.Buffer
-			if err := scanMcpInput(strings.NewReader(input), &upstream, &discarded, ids); err != nil {
+			if err := scanMcpInput(strings.NewReader(input), &upstream, &discarded, ids, contextModeTools); err != nil {
 				t.Fatal(err)
 			}
 			response := []byte(`{"jsonrpc":"2.0","id":` + tt.response + `,"result":{"tools":[{"name":"hidden"}]}}`)
-			if !filterContextModeTools(response, ids) {
+			if !filterMcpTools(response, ids) {
 				t.Fatalf("IDs did not correlate: request %s, response %s", tt.request, tt.response)
 			}
 		})
@@ -252,16 +299,16 @@ func TestToolsListIDsCorrelateSemanticJSONValues(t *testing.T) {
 func TestServerRequestDoesNotConsumeToolsListID(t *testing.T) {
 	ids := &mcpRequestIDs{ids: map[string]bool{}}
 	var upstream, discarded bytes.Buffer
-	if err := scanMcpInput(strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`+"\n"), &upstream, &discarded, ids); err != nil {
+	if err := scanMcpInput(strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`+"\n"), &upstream, &discarded, ids, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	serverRequest := []byte(`{"jsonrpc":"2.0","id":1,"method":"notifications/request"}`)
-	if filterContextModeTools(serverRequest, ids) {
+	if filterMcpTools(serverRequest, ids) {
 		t.Fatal("server request consumed pending tools/list ID")
 	}
 	response := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"hidden"},{"name":"ctx_search"}]}}`)
 	var output bytes.Buffer
-	if err := scanMcpOutput(strings.NewReader(string(response)+"\n"), &output, ids); err != nil {
+	if err := scanMcpOutput(strings.NewReader(string(response)+"\n"), &output, ids, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	filtered := output.Bytes()
@@ -274,7 +321,7 @@ func TestMCPContentLengthFraming(t *testing.T) {
 	message := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ctx_search"}}`)
 	input := fmt.Sprintf("Content-Length: %d\r\nX-Test: yes\r\n\r\n%s", len(message), message)
 	var upstream, output bytes.Buffer
-	if err := scanMcpInput(strings.NewReader(input), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}); err != nil {
+	if err := scanMcpInput(strings.NewReader(input), &upstream, &output, &mcpRequestIDs{ids: map[string]bool{}}, contextModeTools); err != nil {
 		t.Fatal(err)
 	}
 	want := fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(message), message)
@@ -342,7 +389,7 @@ func TestBoundedContextModeProxyReturnsWhenUpstreamCloses(t *testing.T) {
 	defer inputWriter.Close()
 	done := make(chan int, 1)
 	go func() {
-		done <- runMcpProxyIO("", "sh", []string{"sh", "-c", "exit 0"}, nil, inputReader, io.Discard, io.Discard, true)
+		done <- runMcpProxyIO("", "sh", []string{"sh", "-c", "exit 0"}, nil, inputReader, io.Discard, io.Discard, "context-mode")
 	}()
 	select {
 	case code := <-done:

--- a/internal/commands/mcp_proxy_test.go
+++ b/internal/commands/mcp_proxy_test.go
@@ -168,6 +168,13 @@ func TestHeadroomPolicyFiltersAndRejectsHiddenTools(t *testing.T) {
 	if !strings.Contains(output.String(), `"id":3`) || !strings.Contains(output.String(), `"code":-32601`) || !strings.Contains(output.String(), `tool \"headroom_stats\" is not available`) {
 		t.Fatalf("unexpected denied response: %q", output.String())
 	}
+	output.Reset()
+	if err := scanMcpInput(strings.NewReader(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"headroom_stats"}}`+"\n"), &upstream, &output, ids, allowed); err != nil {
+		t.Fatal(err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("denied notification produced response: %q", output.String())
+	}
 
 	output.Reset()
 	response := `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"headroom_compress"},{"name":"headroom_stats"},{"name":"headroom_retrieve"},{"name":"headroom_read"}]}}` + "\n"
@@ -194,6 +201,72 @@ func TestUnboundedProxyPassesThroughTools(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), "headroom_stats") {
 		t.Fatalf("unbounded proxy filtered upstream tools: %q", output.String())
+	}
+}
+
+func TestMcpProxyAfterStartRunsOnceOnlyAfterSuccessfulStart(t *testing.T) {
+	successPath := "sh"
+	successArgv := []string{"sh", "-c", "exit 0"}
+	if runtime.GOOS == "windows" {
+		successPath = "cmd"
+		successArgv = []string{"cmd", "/c", "exit 0"}
+	}
+	tests := []struct {
+		name    string
+		tool    string
+		path    string
+		argv    []string
+		wantRun bool
+	}{
+		{"unbounded success", "", successPath, successArgv, true},
+		{"unbounded failure", "", filepath.Join(t.TempDir(), "missing"), []string{"missing"}, false},
+		{"bounded success", "context-mode", successPath, successArgv, true},
+		{"bounded failure", "context-mode", filepath.Join(t.TempDir(), "missing"), []string{"missing"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			code := runMcpProxyIOAfterStart("", tt.path, tt.argv, nil, strings.NewReader(""), io.Discard, io.Discard, tt.tool, func() {
+				calls++
+			})
+			if tt.wantRun && code != 0 {
+				t.Fatalf("proxy exit code = %d, want 0", code)
+			}
+			if !tt.wantRun && code == 0 {
+				t.Fatal("proxy unexpectedly succeeded")
+			}
+			wantCalls := 0
+			if tt.wantRun {
+				wantCalls = 1
+			}
+			if calls != wantCalls {
+				t.Fatalf("afterStart calls = %d, want %d", calls, wantCalls)
+			}
+		})
+	}
+}
+
+func TestBoundedProxyOutputDoesNotDeadlock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh fixture")
+	}
+	inputReader, inputWriter := io.Pipe()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runMcpProxyIO("", "sh", []string{"sh", "-c", "printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}'"}, nil, inputReader, &output, io.Discard, "context-mode")
+	}()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("proxy exit code = %d", code)
+		}
+		if got := strings.TrimSpace(output.String()); got != `{"jsonrpc":"2.0","id":1,"result":{}}` {
+			t.Fatalf("output = %q", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bounded proxy deadlocked while forwarding child output")
 	}
 }
 

--- a/internal/commands/proxy.go
+++ b/internal/commands/proxy.go
@@ -1,0 +1,242 @@
+package commands
+
+import (
+	"github.com/HoangP8/tokless/internal/agents"
+	headroompkg "github.com/HoangP8/tokless/internal/headroom"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+// ProxyAgentIDs is the full `tokless proxy` agent vocabulary in display order:
+// wired agents first (config-file injection), then manual/env agents, then MCP-only.
+func ProxyAgentIDs() []string {
+	return []string{
+		"claude", "codex", "opencode", "omp", "kilo", "pi", "droid", // wired
+		"grok", "copilot", "cline", "cursor", // manual / launch-env
+		"antigravity", // MCP-only
+	}
+}
+
+func resolveProxyAgents(opts InitOptions) []string {
+	if opts.Agents != nil {
+		return opts.Agents
+	}
+	return ProxyAgentIDs()
+}
+
+// proxyInstructions returns the exact manual/env guidance for agents that
+// tokless cannot wire via a config file.
+func proxyInstructions(id string) []string {
+	base := headroompkg.ProxyURL()
+	openai := headroompkg.ProxyOpenAIURL()
+	switch id {
+	case "grok":
+		return []string{"export GROK_MODELS_BASE_URL=" + openai}
+	case "copilot":
+		return []string{"export COPILOT_PROVIDER_BASE_URL=" + openai}
+	case "cline":
+		return []string{
+			"VS Code: Cline settings → API Provider",
+			"  Anthropic Base URL: " + base,
+			"  OpenAI Compatible Base URL: " + openai,
+		}
+	case "cursor":
+		return []string{
+			"Cursor settings → Models → OpenAI API Key → Override OpenAI Base URL",
+			"  Base URL: " + openai,
+		}
+	}
+	return nil
+}
+
+func configureProxyAgent(id string) bool {
+	switch id {
+	case "claude":
+		_, _ = agents.ConfigureClaudeProxy()
+		return agents.ClaudeProxyWired()
+	case "codex":
+		_, _ = agents.ConfigureCodexProxy()
+		return agents.CodexProxyWired()
+	case "opencode":
+		_, _ = agents.ConfigureOpenCodeProxy()
+		return agents.OpenCodeProxyWired()
+	case "omp":
+		_, _ = agents.ConfigureOmpProxy()
+		return agents.OmpProxyWired()
+	case "kilo":
+		_, _ = agents.ConfigureKiloProxy()
+		return agents.KiloProxyWired()
+	case "pi":
+		_, _ = agents.ConfigurePiProxy()
+		return agents.PiProxyWired()
+	case "droid":
+		_, _ = agents.ConfigureDroidProxy()
+		return agents.DroidProxyWired()
+	}
+	return false
+}
+
+var removeProxyAgent = removeProxyAgentImpl
+
+func removeProxyAgentImpl(id string) bool {
+	var removed bool
+	switch id {
+	case "claude":
+		removed = agents.RemoveClaudeProxy()
+	case "codex":
+		removed = agents.RemoveCodexProxy()
+	case "opencode":
+		removed = agents.RemoveOpenCodeProxy()
+	case "omp":
+		removed = agents.RemoveOmpProxy()
+	case "kilo":
+		removed = agents.RemoveKiloProxy()
+	case "pi":
+		removed = agents.RemovePiProxy()
+	case "droid":
+		removed = agents.RemoveDroidProxy()
+	}
+	if removed && proxyAgentWired(id) {
+		return false
+	}
+	return removed
+}
+
+var proxyAgentWired = proxyAgentWiredImpl
+
+func proxyAgentWiredImpl(id string) bool {
+	switch id {
+	case "claude":
+		return agents.ClaudeProxyWired()
+	case "codex":
+		return agents.CodexProxyWired()
+	case "opencode":
+		return agents.OpenCodeProxyWired()
+	case "omp":
+		return agents.OmpProxyWired()
+	case "kilo":
+		return agents.KiloProxyWired()
+	case "pi":
+		return agents.PiProxyWired()
+	case "droid":
+		return agents.DroidProxyWired()
+	}
+	return false
+}
+
+var stopProxy = headroompkg.StopProxy
+var proxyRunning = headroompkg.ProxyRunning
+
+// RunProxyUp starts the headroom proxy daemon and points agents at it.
+func RunProxyUp(opts InitOptions) int {
+	cmdHeader("proxy up", "start the headroom HTTP proxy and point agents at it")
+	if headroompkg.ResolveHeadroomBin() == "" {
+		util.L.Err("headroom binary not found — run `tokless` first to install headroom")
+		return 1
+	}
+	if err := headroompkg.StartProxy(); err != nil {
+		util.L.Err(err.Error())
+		return 1
+	}
+	wired, failed := 0, 0
+	for _, id := range resolveProxyAgents(opts) {
+		switch {
+		case id == "antigravity":
+			util.L.Raw("  " + util.C.Gray(util.Sym.Bullet+" antigravity: MCP-only (no client base-URL knob)"))
+		case proxyInstructions(id) != nil:
+			util.L.Raw("  " + util.Sym.Bullet + " " + id + ": manual (cannot auto-wire) — set:")
+			for _, line := range proxyInstructions(id) {
+				util.L.Raw("      " + line)
+			}
+		case configureProxyAgent(id):
+			util.L.Ok(id + ": wired to " + agents.ProxyEndpointFor(id))
+			wired++
+		default:
+			util.L.Err(id + ": not wired (differing existing config value, or write failed)")
+			failed++
+		}
+	}
+	util.L.Raw("")
+	if failed > 0 {
+		return 1
+	}
+	if wired == 0 {
+		util.L.Raw("  " + util.C.Gray("No agents wired."))
+	}
+	return 0
+}
+
+// RunProxyDown unwires agents, then stops the daemon when operating on the
+// complete agent set and every currently-wired config agent was unwired.
+func RunProxyDown(opts InitOptions) int {
+	cmdHeader("proxy down", "unwire agents and stop the headroom HTTP proxy")
+	failed := 0
+	selected := opts.Agents != nil
+	wiredBefore := map[string]bool{}
+	for _, id := range resolveProxyAgents(opts) {
+		if proxyInstructions(id) == nil && id != "antigravity" {
+			wiredBefore[id] = proxyAgentWired(id)
+		}
+	}
+	for _, id := range resolveProxyAgents(opts) {
+		if id == "antigravity" || proxyInstructions(id) != nil {
+			continue // nothing written; nothing to unwire
+		}
+		switch {
+		case removeProxyAgent(id):
+			util.L.Ok(id + ": proxy wiring removed")
+		case wiredBefore[id]:
+			util.L.Err(id + ": unwire failed — removal did not take effect; leaving config untouched")
+			failed++
+		default:
+			util.L.Raw("  " + util.C.Gray(util.Sym.Bullet+" "+id+": not wired"))
+		}
+	}
+	if selected {
+		util.L.Raw("")
+		if failed > 0 {
+			return 1
+		}
+		return 0
+	}
+	for id, wired := range wiredBefore {
+		if wired && proxyAgentWired(id) {
+			failed++
+		}
+	}
+	if failed > 0 {
+		util.L.Raw("")
+		return 1
+	}
+	if err := stopProxy(); err != nil {
+		util.L.Err(err.Error())
+		return 1
+	}
+	util.L.Raw("")
+	return 0
+}
+
+// RunProxyStatus prints daemon + per-agent capability and wiring state.
+func RunProxyStatus(opts InitOptions) int {
+	cmdHeader("proxy status", "headroom HTTP-proxy daemon and agent wiring")
+	url := headroompkg.ProxyURL()
+	if proxyRunning() {
+		util.L.Raw("  " + statusOK("proxy: running on "+url))
+	} else {
+		util.L.Raw("  " + statusWarn("proxy: not running ("+url+")"))
+	}
+	for _, id := range resolveProxyAgents(opts) {
+		detection := agents.DetectProxy(id)
+		label := id + ": " + string(detection.Capability.WireKind) + ", " + string(detection.Capability.Protocol) + " — " + string(detection.State)
+		if detection.Detail != "" {
+			label += " (" + detection.Detail + ")"
+		}
+		if detection.State == agents.ProxyStateManaged && detection.Capability.WireKind != agents.ProxyWireManual && detection.Capability.WireKind != agents.ProxyWireMCPOnly {
+			label += " " + util.C.Dim("→") + " " + agents.ProxyEndpointFor(id)
+			util.L.Raw("  " + statusOK(label))
+		} else {
+			util.L.Raw("  " + util.C.Gray(util.Sym.Bullet+" "+label))
+		}
+	}
+	util.L.Raw("")
+	return 0
+}

--- a/internal/commands/proxy_test.go
+++ b/internal/commands/proxy_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/HoangP8/tokless/internal/agents"
+	headroompkg "github.com/HoangP8/tokless/internal/headroom"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+// TestProxyInstructionsEndpointShapes pins the manual/env guidance to the same
+// /v1-vs-bare split, matching each upstream CLI's expected base-URL shape.
+func TestProxyInstructionsEndpointShapes(t *testing.T) {
+	openai := headroompkg.ProxyOpenAIURL()
+	bare := headroompkg.ProxyURL()
+
+	if got := proxyInstructions("grok"); len(got) != 1 || got[0] != "export GROK_MODELS_BASE_URL="+openai {
+		t.Fatalf("grok instructions = %v", got)
+	}
+	if got := proxyInstructions("copilot"); len(got) != 1 || got[0] != "export COPILOT_PROVIDER_BASE_URL="+openai {
+		t.Fatalf("copilot instructions = %v", got)
+	}
+
+	cline := strings.Join(proxyInstructions("cline"), "\n")
+	if !strings.Contains(cline, "Anthropic Base URL: "+bare) {
+		t.Fatalf("cline instructions missing bare anthropic URL: %q", cline)
+	}
+	if !strings.Contains(cline, "OpenAI Compatible Base URL: "+openai) {
+		t.Fatalf("cline instructions missing openai /v1 URL: %q", cline)
+	}
+
+	cursor := strings.Join(proxyInstructions("cursor"), "\n")
+	if !strings.Contains(cursor, "Base URL: "+openai) {
+		t.Fatalf("cursor instructions missing openai /v1 URL: %q", cursor)
+	}
+
+	if proxyInstructions("claude") != nil || proxyInstructions("codex") != nil || proxyInstructions("antigravity") != nil {
+		t.Fatal("wired/MCP-only agents must have no manual instructions")
+	}
+}
+
+func TestRunProxyStatusProbesDaemonOnceAndDoesNotWireManual(t *testing.T) {
+	t.Setenv("GROK_MODELS_BASE_URL", headroompkg.ProxyOpenAIURL())
+	var probes int
+	oldRunning := proxyRunning
+	proxyRunning = func() bool { probes++; return true }
+	t.Cleanup(func() { proxyRunning = oldRunning })
+	logs, err := util.CaptureLogs(func() error {
+		if got := RunProxyStatus(InitOptions{Agents: []string{"grok"}}); got != 0 {
+			t.Fatalf("status exit code = %d", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probes != 1 {
+		t.Fatalf("daemon probes = %d, want 1", probes)
+	}
+	if strings.Contains(logs, "→") || strings.Contains(logs, headroompkg.ProxyOpenAIURL()) {
+		t.Fatalf("manual status rendered as wired endpoint: %q", logs)
+	}
+	if !strings.Contains(logs, string(agents.ProxyStateUnknown)) || !strings.Contains(logs, "ownership unknown") {
+		t.Fatalf("manual status missing truthful state: %q", logs)
+	}
+}
+
+func TestRunProxyDownRetainsDaemonForSelectedSubset(t *testing.T) {
+	var stops int
+	oldStop := stopProxy
+	stopProxy = func() error { stops++; return nil }
+	t.Cleanup(func() { stopProxy = oldStop })
+	if got := RunProxyDown(InitOptions{Agents: []string{"grok"}}); got != 0 {
+		t.Fatalf("proxy down subset exit code = %d, want 0", got)
+	}
+	if stops != 0 {
+		t.Fatalf("stop proxy call count = %d, want 0", stops)
+	}
+}
+
+func TestRunProxyDownStopsAfterFullUnwire(t *testing.T) {
+	var stops int
+	oldStop := stopProxy
+	stopProxy = func() error { stops++; return nil }
+	t.Cleanup(func() { stopProxy = oldStop })
+	if got := RunProxyDown(InitOptions{}); got != 0 {
+		t.Fatalf("proxy down full exit code = %d, want 0", got)
+	}
+	if stops != 1 {
+		t.Fatalf("stop proxy call count = %d, want 1", stops)
+	}
+}
+
+func TestRunProxyDownRetainsDaemonWhenUnwireFails(t *testing.T) {
+	var stops int
+	oldStop := stopProxy
+	stopProxy = func() error { stops++; return nil }
+	t.Cleanup(func() { stopProxy = oldStop })
+	oldRemove := removeProxyAgent
+	removeProxyAgent = func(string) bool { return false }
+	t.Cleanup(func() { removeProxyAgent = oldRemove })
+	oldWired := proxyAgentWired
+	proxyAgentWired = func(string) bool { return true }
+	t.Cleanup(func() { proxyAgentWired = oldWired })
+	if got := RunProxyDown(InitOptions{}); got == 0 {
+		t.Fatal("proxy down must report failed unwire")
+	}
+	if stops != 0 {
+		t.Fatalf("stop proxy call count = %d, want 0", stops)
+	}
+}

--- a/internal/commands/runmcp.go
+++ b/internal/commands/runmcp.go
@@ -12,18 +12,34 @@ import (
 func RunMcp(argv []string) int {
 	agent := ""
 	workspace := ""
-	if len(argv) >= 2 && argv[0] == "--agent" {
-		agent = argv[1]
-		argv = argv[2:]
-	}
-	if len(argv) >= 2 && argv[0] == "--workspace" {
-		workspace = argv[1]
-		argv = argv[2:]
-	}
 	contextMode := false
-	if len(argv) > 0 && argv[0] == "--context-mode" {
-		contextMode = true
-		argv = argv[1:]
+	tool := ""
+	for len(argv) > 0 {
+		switch argv[0] {
+		case "--agent", "--workspace", "--tool":
+			if len(argv) < 2 || argv[1] == "" || strings.HasPrefix(argv[1], "--") {
+				return 1
+			}
+			switch argv[0] {
+			case "--agent":
+				agent = argv[1]
+			case "--workspace":
+				workspace = argv[1]
+			case "--tool":
+				tool = argv[1]
+			}
+			argv = argv[2:]
+		case "--context-mode":
+			contextMode = true
+			argv = argv[1:]
+		default:
+			goto command
+		}
+	}
+
+command:
+	if contextMode && tool == "" {
+		tool = "context-mode"
 	}
 	if len(argv) == 0 {
 		return 1
@@ -51,7 +67,7 @@ func RunMcp(argv []string) int {
 			go func() { _ = RunCodegraphMcpBootstrap(workspace) }()
 		}
 	}
-	return runMcpProxyAfterStart(agent, path, argv, os.Environ(), contextMode, afterStart)
+	return runMcpProxyAfterStart(agent, path, argv, os.Environ(), tool, afterStart)
 }
 
 // codegraphMcpCommand returns CodeGraph executable for direct and cmd /c forms.

--- a/internal/commands/runmcp_test.go
+++ b/internal/commands/runmcp_test.go
@@ -242,3 +242,37 @@ func TestRunMcpDoesNotSyncExistingCodegraph(t *testing.T) {
 		t.Fatalf("calls = %q; want proxy launch without external sync", got)
 	}
 }
+
+func TestRunMcpParsesHeadroomToolWithoutChangingChildArgs(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "headroom")
+	log := filepath.Join(t.TempDir(), "args")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nprintf '%s' \"$*\" > \"$RUN_MCP_LOG\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RUN_MCP_LOG", log)
+	if code := RunMcp([]string{"--tool", "headroom", "--workspace", t.TempDir(), bin, "mcp", "serve"}); code != 0 {
+		t.Fatalf("RunMcp = %d", code)
+	}
+	got, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "mcp serve" {
+		t.Fatalf("child args = %q, want %q", got, "mcp serve")
+	}
+}
+
+func TestRunMcpRejectsMalformedToolBeforeLaunch(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "started")
+	bin := filepath.Join(t.TempDir(), "child")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\ntouch \"$RUN_MCP_MARKER\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RUN_MCP_MARKER", marker)
+	if code := RunMcp([]string{"--tool", "--context-mode", bin}); code == 0 {
+		t.Fatal("malformed --tool succeeded")
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("child ran despite malformed --tool: %v", err)
+	}
+}

--- a/internal/headroom/headroom.go
+++ b/internal/headroom/headroom.go
@@ -1,0 +1,297 @@
+package headroom
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/HoangP8/tokless/internal/agents"
+	"github.com/HoangP8/tokless/internal/core"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+const headroomPackage = "headroom-ai[mcp]"
+const headroomProbeTimeout = 500 * time.Millisecond
+
+var runHeadroom = func(command string, args, env []string, ctx context.Context) util.ExecResult {
+	return util.Run(command, args, util.RunOptions{Capture: true, Env: env, Ctx: ctx})
+}
+
+func headroomInstallArgs(upgrade bool) []string {
+	args := []string{"tool", "install"}
+	if upgrade {
+		args = append(args, "--upgrade")
+	}
+	return append(args, "--python", "3.13", headroomPackage)
+}
+func headroomPythonInstallArgs() []string { return []string{"python", "install", "3.13"} }
+func headroomNativeBuildRisk() bool       { return headroomNativeBuildRiskFor(runtime.GOOS, runtime.GOARCH) }
+func headroomNativeBuildRiskFor(goos, goarch string) bool {
+	return goos == "windows" || goos == "darwin" && goarch == "amd64"
+}
+
+func headroomFailure(stage string, result util.ExecResult) error {
+	return headroomFailureFor(stage, result, headroomNativeBuildRisk())
+}
+
+func headroomFailureFor(stage string, result util.ExecResult, nativeRisk bool) error {
+	hint := ""
+	if nativeRisk {
+		hint = " Rust/native toolchain may be required on this platform. Manual: " + strings.Join(append([]string{util.HeadroomPathsResolved().UV}, headroomInstallArgs(false)...), " ")
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail != "" {
+		detail = ": " + strings.Split(detail, "\n")[0]
+	}
+	return fmt.Errorf("headroom %s failed%s%s", stage, detail, hint)
+}
+
+func headroomUV() (string, error) {
+	p := util.HeadroomPathsResolved()
+	if util.Exists(p.UV) && headroomUVWorks(p.UV) {
+		return p.UV, nil
+	}
+	if system := util.Which("uv"); system != "" && headroomUVWorks(system) {
+		return system, nil
+	}
+	if err := util.EnsureDir(filepath.Dir(p.UV)); err != nil {
+		return "", err
+	}
+	var command string
+	var args []string
+	if util.IsWin {
+		command = "powershell"
+		args = []string{"-ExecutionPolicy", "ByPass", "-c", "$env:UV_INSTALL_DIR=$env:TOKLESS_HEADROOM_UV_INSTALL_DIR;$env:UV_NO_MODIFY_PATH=1;irm https://astral.sh/uv/install.ps1 | iex"}
+	} else {
+		command = "sh"
+		args = []string{"-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"}
+	}
+	env := append(util.HeadroomUVBootstrapEnv(), "TOKLESS_HEADROOM_UV_INSTALL_DIR="+filepath.Dir(p.UV))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := runHeadroom(command, args, env, ctx)
+	if result.Code != 0 || !util.Exists(p.UV) || !headroomUVWorks(p.UV) {
+		return "", headroomFailure("uv bootstrap", result)
+	}
+	return p.UV, nil
+}
+
+func headroomUVWorks(uv string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return runHeadroom(uv, []string{"--version"}, util.HeadroomEnv(), ctx).Code == 0
+}
+
+func headroomServeProbe() error {
+	ctx, cancel := context.WithTimeout(context.Background(), headroomProbeTimeout)
+	defer cancel()
+	started := time.Now()
+	result := runHeadroom(util.HeadroomBin(), []string{"mcp", "serve"}, nil, ctx)
+	if ctx.Err() == context.DeadlineExceeded && time.Since(started) >= headroomProbeTimeout {
+		return nil
+	}
+	return headroomFailure("executable verification", result)
+}
+
+func EnsureInstalled(opts core.RunOpts) (bool, error) {
+	if os.Getenv("TOKLESS_TEST") == "1" {
+		return true, nil
+	}
+	if opts.DryRun {
+		util.L.Sub("[dry-run] would install headroom-ai[mcp] with managed Python 3.13")
+		return true, nil
+	}
+	opts.Reportf("uv bootstrap", 0.1)
+	uv, err := headroomUV()
+	if err != nil {
+		return false, err
+	}
+	if util.HeadroomInstalled() && !opts.Upgrade {
+		if err := headroomServeProbe(); err != nil {
+			return false, err
+		}
+		opts.Reportf("already installed", 1)
+		return true, nil
+	}
+	opts.Reportf("managed Python", 0.3)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	if result := runHeadroom(uv, headroomPythonInstallArgs(), util.HeadroomEnv(), ctx); result.Code != 0 {
+		return false, headroomFailure("managed Python", result)
+	}
+	opts.Reportf("package install", 0.5)
+	result := runHeadroom(uv, headroomInstallArgs(opts.Upgrade), util.HeadroomEnv(), ctx)
+	if result.Code != 0 {
+		return false, headroomFailure("package install", result)
+	}
+	if !util.HeadroomInstalled() {
+		return false, fmt.Errorf("headroom executable verification failed: %s", util.HeadroomBin())
+	}
+	if err := headroomServeProbe(); err != nil {
+		return false, err
+	}
+	opts.Reportf("ready", 1)
+	return true, nil
+}
+
+func ConfigureMcp(agent string) bool {
+	switch agent {
+	case "claude":
+		agents.ConfigureClaudeMcp("headroom")
+		return true
+	case "opencode":
+		agents.ConfigureOpenCodeMcp("headroom")
+		return true
+	case "codex":
+		agents.ConfigureCodexMcp("headroom")
+		return true
+	case "cursor":
+		changed, _ := agents.ConfigureCursorMcp("headroom")
+		return changed || agents.CursorMcpHas("headroom")
+	case "antigravity":
+		agents.ConfigureAntigravityMcp("headroom")
+		return true
+	case "copilot":
+		agents.ConfigureCopilotMcp("headroom")
+		return true
+	case "droid":
+		agents.ConfigureDroidMcp("headroom")
+		return true
+	case "grok":
+		_, _, err := agents.ConfigureGrokMcp("headroom")
+		return err == nil
+	case "pi":
+		agents.ConfigurePiMcp("headroom")
+		return true
+	case "omp":
+		changed, _ := agents.ConfigureOmpMcp("headroom")
+		return changed || agents.OmpMcpHas("headroom")
+	case "kilo":
+		spawn := util.McpSpawnFor("headroom")
+		_, _, err := agents.ConfigureKiloMcpSafe("headroom", append([]string{spawn.Command}, spawn.Args...))
+		return err == nil
+	case "cline":
+		spawn := util.McpSpawnFor("headroom")
+		_, _, err := agents.ConfigureClineMcpSafe("headroom", append([]string{spawn.Command}, spawn.Args...))
+		return err == nil
+	}
+	return false
+}
+
+func McpMatches(agent string) bool   { found, matches := McpState(agent); return found && matches }
+func CanConfigure(agent string) bool { found, matches := McpState(agent); return !found || matches }
+
+func McpState(agent string) (found, matches bool) {
+	spawn := util.McpSpawnFor("headroom")
+	command := append([]string{spawn.Command}, spawn.Args...)
+	entry := func() *util.OrderedMap {
+		m := util.NewOrderedMap()
+		m.Set("type", "stdio")
+		m.Set("command", spawn.Command)
+		m.Set("args", toAny(spawn.Args))
+		return m
+	}
+	jsonEntry := func(path, key string, expected *util.OrderedMap) (bool, bool) {
+		raw, ok := util.ReadFileSafe(path)
+		if !ok {
+			return false, false
+		}
+		cfg := util.TryParseJsonc(raw)
+		if cfg == nil {
+			return false, false
+		}
+		v, ok := cfg.Get(key)
+		if !ok {
+			return false, false
+		}
+		m, ok := v.(*util.OrderedMap)
+		if !ok {
+			return false, false
+		}
+		value, ok := m.Get("headroom")
+		return ok, ok && util.StringifyJSON(value) == util.StringifyJSON(expected)
+	}
+	switch agent {
+	case "claude":
+		return jsonEntry(util.ClaudeCodePaths().GlobalJSON, "mcpServers", entry())
+	case "opencode":
+		m := util.NewOrderedMap()
+		m.Set("type", "local")
+		m.Set("command", toAny(command))
+		m.Set("enabled", true)
+		return jsonEntry(util.OpenCodePathsResolved().Config, "mcp", m)
+	case "codex":
+		raw, _ := util.ReadFileSafe(util.CodexPathsResolved().Config)
+		if !util.HasBlock(raw, "mcp_servers.headroom") {
+			return false, false
+		}
+		m := util.NewTomlBlock("mcp_servers.headroom")
+		m.Set("command", spawn.Command)
+		m.Set("args", spawn.Args)
+		m.Set("enabled", true)
+		m.Set("default_tools_approval_mode", "approve")
+		return true, util.UpsertBlock(raw, m, false) == raw
+	case "cursor":
+		return jsonEntry(util.CursorGlobalMcpPath(), "mcpServers", entry())
+	case "antigravity":
+		m := util.NewOrderedMap()
+		m.Set("command", spawn.Command)
+		m.Set("args", toAny(spawn.Args))
+		m.Set("trust", true)
+		found, matches = false, true
+		for _, path := range []string{util.AntigravityPathsResolved().McpConfigCLI, filepath.Join(util.Home(), ".gemini", "antigravity-cli", "mcp_config.json")} {
+			seen, same := jsonEntry(path, "mcpServers", m)
+			if seen {
+				found = true
+				matches = matches && same
+			}
+		}
+		return found, matches
+	case "copilot":
+		cli := util.NewOrderedMap()
+		cli.Set("type", "local")
+		cli.Set("command", spawn.Command)
+		cli.Set("args", toAny(spawn.Args))
+		cli.Set("tools", []any{"*"})
+		foundCLI, matchesCLI := jsonEntry(util.CopilotPathsResolved().McpConfig, "mcpServers", cli)
+		foundIDE, matchesIDE := jsonEntry(filepath.Join(agents.IdeProjectRoot(), ".vscode", "mcp.json"), "servers", entry())
+		return foundCLI || foundIDE, foundCLI && matchesCLI && foundIDE && matchesIDE
+	case "droid":
+		m := util.NewOrderedMap()
+		m.Set("command", spawn.Command)
+		m.Set("args", toAny(spawn.Args))
+		m.Set("enabledTools", toAny(agents.HeadroomDroidToolNames))
+		return jsonEntry(filepath.Join(util.Home(), ".factory", "mcp.json"), "mcpServers", m)
+	case "grok":
+		return agents.GrokHeadroomMcpHas(), agents.GrokHeadroomMcpHas()
+	case "pi":
+		m := util.NewOrderedMap()
+		m.Set("command", spawn.Command)
+		m.Set("args", toAny(spawn.Args))
+		m.Set("lifecycle", "lazy")
+		m.Set("directTools", true)
+		return jsonEntry(filepath.Join(agents.PiAgentDirResolved(), "mcp.json"), "mcpServers", m)
+	case "omp":
+		return agents.OmpMcpHas("headroom"), agents.OmpMcpHas("headroom")
+	case "kilo":
+		return agents.KiloMcpConfigured("headroom"), agents.KiloMcpMatches("headroom", command)
+	case "cline":
+		return agents.ClineMcpConfigured("headroom"), agents.ClineMcpMatches("headroom", command)
+	}
+	return false, false
+}
+
+func toAny(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/internal/headroom/headroom_test.go
+++ b/internal/headroom/headroom_test.go
@@ -1,0 +1,173 @@
+package headroom
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/HoangP8/tokless/internal/core"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+func TestHeadroomInstallArgsAndNativeRisk(t *testing.T) {
+	if got, want := headroomPythonInstallArgs(), []string{"python", "install", "3.13"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Python install args = %v, want %v", got, want)
+	}
+	if got, want := headroomInstallArgs(false), []string{"tool", "install", "--python", "3.13", "headroom-ai[mcp]"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("install args = %v, want %v", got, want)
+	}
+	if got, want := headroomInstallArgs(true), []string{"tool", "install", "--upgrade", "--python", "3.13", "headroom-ai[mcp]"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("upgrade args = %v, want %v", got, want)
+	}
+	if !headroomNativeBuildRiskFor("windows", "amd64") || !headroomNativeBuildRiskFor("darwin", "amd64") || headroomNativeBuildRiskFor("darwin", "arm64") || headroomNativeBuildRiskFor("linux", "amd64") {
+		t.Fatal("native build risk classification is incorrect")
+	}
+}
+
+func TestHeadroomInstallUsesManagedUVState(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("TOKLESS_TEST", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	p := util.HeadroomPathsResolved()
+	if err := os.MkdirAll(filepath.Dir(p.UV), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.UV, []byte("managed uv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := runHeadroom
+	t.Cleanup(func() { runHeadroom = old })
+	var calls [][]string
+	runHeadroom = func(command string, args, env []string, ctx context.Context) util.ExecResult {
+		calls = append(calls, append([]string{command}, args...))
+		if command == util.HeadroomBin() {
+			<-ctx.Done()
+			return util.ExecResult{Code: 1}
+		}
+		if command != p.UV {
+			return util.ExecResult{Code: 1, Stderr: "unexpected uv"}
+		}
+		for _, item := range util.HeadroomEnv() {
+			if !containsString(env, item) {
+				return util.ExecResult{Code: 1, Stderr: "missing managed env"}
+			}
+		}
+		if reflect.DeepEqual(args, headroomInstallArgs(false)) || reflect.DeepEqual(args, headroomInstallArgs(true)) {
+			if err := os.MkdirAll(filepath.Dir(util.HeadroomBin()), 0o755); err != nil {
+				return util.ExecResult{Code: 1, Stderr: err.Error()}
+			}
+			if err := os.WriteFile(util.HeadroomBin(), []byte("headroom"), 0o755); err != nil {
+				return util.ExecResult{Code: 1, Stderr: err.Error()}
+			}
+		}
+		return util.ExecResult{}
+	}
+	if ok, err := EnsureInstalled(core.RunOpts{}); err != nil || !ok {
+		t.Fatalf("install = %v, %v", ok, err)
+	}
+	if len(calls) != 4 || !reflect.DeepEqual(calls[0], []string{p.UV, "--version"}) || !reflect.DeepEqual(calls[1], append([]string{p.UV}, headroomPythonInstallArgs()...)) || !reflect.DeepEqual(calls[2], append([]string{p.UV}, headroomInstallArgs(false)...)) {
+		t.Fatalf("install call = %v", calls)
+	}
+	if ok, err := EnsureInstalled(core.RunOpts{Upgrade: true}); err != nil || !ok {
+		t.Fatalf("upgrade = %v, %v", ok, err)
+	}
+	if len(calls) != 8 || !reflect.DeepEqual(calls[6], append([]string{p.UV}, headroomInstallArgs(true)...)) {
+		t.Fatalf("upgrade calls = %v", calls)
+	}
+}
+
+func TestHeadroomServeProbeRequiresLiveServer(t *testing.T) {
+	old := runHeadroom
+	t.Cleanup(func() { runHeadroom = old })
+	runHeadroom = func(string, []string, []string, context.Context) util.ExecResult {
+		return util.ExecResult{Code: 127, Stderr: "bad entry point"}
+	}
+	if err := headroomServeProbe(); err == nil || !strings.Contains(err.Error(), "executable verification") {
+		t.Fatalf("immediate failure = %v", err)
+	}
+	runHeadroom = func(_ string, _ []string, _ []string, ctx context.Context) util.ExecResult {
+		<-ctx.Done()
+		return util.ExecResult{Code: 1}
+	}
+	if err := headroomServeProbe(); err != nil {
+		t.Fatalf("live server probe = %v", err)
+	}
+}
+
+func TestHeadroomFailedUpgradeKeepsManagedExecutable(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("TOKLESS_TEST", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	p := util.HeadroomPathsResolved()
+	if err := os.MkdirAll(filepath.Dir(p.UV), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.UV, []byte("managed uv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(util.HeadroomBin()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(util.HeadroomBin(), []byte("working"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := runHeadroom
+	t.Cleanup(func() { runHeadroom = old })
+	upgradeCalled := false
+	runHeadroom = func(_ string, args, _ []string, _ context.Context) util.ExecResult {
+		if reflect.DeepEqual(args, []string{"--version"}) {
+			return util.ExecResult{}
+		}
+		if reflect.DeepEqual(args, headroomPythonInstallArgs()) {
+			return util.ExecResult{}
+		}
+		if reflect.DeepEqual(args, headroomInstallArgs(true)) {
+			upgradeCalled = true
+			return util.ExecResult{Code: 1, Stderr: "build failed"}
+		}
+		t.Fatalf("unexpected Headroom call args: %v", args)
+		return util.ExecResult{Code: 1, Stderr: "build failed"}
+	}
+	if ok, err := EnsureInstalled(core.RunOpts{Upgrade: true}); err == nil || ok || !strings.Contains(err.Error(), "package install") {
+		t.Fatalf("failed upgrade = %v, %v", ok, err)
+	}
+	if !upgradeCalled {
+		t.Fatal("upgrade call was not made")
+	}
+	if got, err := os.ReadFile(util.HeadroomBin()); err != nil || string(got) != "working" {
+		t.Fatalf("existing executable changed: %q, %v", got, err)
+	}
+}
+
+func TestHeadroomFailureIncludesRemediation(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Cleanup(func() { util.SetHomeOverride("") })
+
+	err := headroomFailureFor("package install", util.ExecResult{Code: 1, Stderr: "first detail\nsecond detail"}, true)
+	got := err.Error()
+	if !strings.Contains(got, "headroom package install failed: first detail") {
+		t.Fatalf("failure detail = %q", got)
+	}
+	if !strings.Contains(got, "Rust/native toolchain may be required on this platform") {
+		t.Fatalf("native warning missing: %q", got)
+	}
+	wantCommand := strings.Join(append([]string{util.HeadroomPathsResolved().UV}, headroomInstallArgs(false)...), " ")
+	if !strings.Contains(got, "Manual: "+wantCommand) {
+		t.Fatalf("managed install command missing: %q", got)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/headroom/process_identity_linux.go
+++ b/internal/headroom/process_identity_linux.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package headroom
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type processIdentityInfo struct {
+	Executable string
+	Args       []string
+	Start      string
+}
+
+func processIdentitySupported() bool { return true }
+
+func identifyProcess(pid int) (processIdentityInfo, error) {
+	base := filepath.Join("/proc", fmt.Sprint(pid))
+	executable, err := os.Readlink(filepath.Join(base, "exe"))
+	if err != nil {
+		return processIdentityInfo{}, err
+	}
+	executable, err = filepath.Abs(executable)
+	if err != nil {
+		return processIdentityInfo{}, err
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return processIdentityInfo{}, err
+	}
+	data, err := os.ReadFile(filepath.Join(base, "cmdline"))
+	if err != nil {
+		return processIdentityInfo{}, err
+	}
+	parts := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	if len(parts) < 2 || parts[0] == "" {
+		return processIdentityInfo{}, fmt.Errorf("incomplete process identity")
+	}
+	stat, err := os.ReadFile(filepath.Join(base, "stat"))
+	if err != nil {
+		return processIdentityInfo{}, err
+	}
+	close := strings.LastIndex(string(stat), ")")
+	if close < 0 {
+		return processIdentityInfo{}, fmt.Errorf("incomplete process start identity")
+	}
+	fields := strings.Fields(string(stat)[close+2:])
+	if len(fields) <= 19 {
+		return processIdentityInfo{}, fmt.Errorf("incomplete process start identity")
+	}
+	if _, err := strconv.ParseUint(fields[19], 10, 64); err != nil {
+		return processIdentityInfo{}, err
+	}
+	return processIdentityInfo{Executable: executable, Args: parts[1:], Start: fields[19]}, nil
+}
+
+func killProcess(proc *os.Process) error { return proc.Kill() }
+func processGone(proc *os.Process) bool {
+	_, err := identifyProcess(proc.Pid)
+	return os.IsNotExist(err)
+}

--- a/internal/headroom/process_identity_linux_test.go
+++ b/internal/headroom/process_identity_linux_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package headroom
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIdentifyProcessRealDirectExecutable(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "600")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	identity := waitForProcessIdentity(t, cmd.Process.Pid)
+	wantExecutable, err := normalizedExecutable("/bin/sleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Executable != wantExecutable {
+		t.Fatalf("executable = %q, want %q", identity.Executable, wantExecutable)
+	}
+	wantArgs := []string{"600"}
+	if !equalStrings(identity.Args, wantArgs) {
+		t.Fatalf("argv = %#v, want %#v", identity.Args, wantArgs)
+	}
+	if identity.Start == "" {
+		t.Fatal("start fingerprint is empty")
+	}
+	if !identity.matches("/bin/sleep", wantArgs) {
+		t.Fatal("real direct executable did not match")
+	}
+}
+
+func TestIdentifyProcessRealConsoleScript(t *testing.T) {
+	launcher := filepath.Join(t.TempDir(), "headroom")
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	python, err = filepath.EvalSymlinks(python)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := "#!" + python + "\nimport time\ntime.sleep(600)\n"
+	if err := os.WriteFile(launcher, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(launcher, "proxy", "--port", "8787")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	identity := waitForProcessIdentity(t, cmd.Process.Pid)
+	wantInterpreter, err := normalizedExecutable(python)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Executable != wantInterpreter {
+		t.Fatalf("interpreter = %q, want %q", identity.Executable, wantInterpreter)
+	}
+	wantArgs := []string{launcher, "proxy", "--port", "8787"}
+	if !equalStrings(identity.Args, wantArgs) {
+		t.Fatalf("argv = %#v, want %#v", identity.Args, wantArgs)
+	}
+	if identity.Start == "" {
+		t.Fatal("start fingerprint is empty")
+	}
+	if !identity.matches(launcher, wantArgs[1:]) {
+		t.Fatal("real console script did not match launcher form")
+	}
+	for name, changed := range map[string][]string{
+		"missing argument":    wantArgs[:len(wantArgs)-1],
+		"extra argument":      append(append([]string(nil), wantArgs...), "extra"),
+		"reordered arguments": {launcher, "--port", "proxy", "8787", "value with spaces"},
+	} {
+		if identity.matches(launcher, changed[1:]) {
+			t.Errorf("%s unexpectedly matched", name)
+		}
+	}
+	wrongLauncher := filepath.Join(filepath.Dir(launcher), "other-headroom")
+	if identity.matches(wrongLauncher, wantArgs[1:]) {
+		t.Fatal("wrong launcher unexpectedly matched")
+	}
+	direct := processIdentityInfo{Executable: identity.Executable, Args: []string{"proxy"}, Start: identity.Start}
+	if !direct.matches(identity.Executable, direct.Args) {
+		t.Fatal("direct identity fixture did not match")
+	}
+	direct.Executable = "/usr/bin/python3"
+	if direct.matches(identity.Executable, []string{"proxy"}) {
+		t.Fatal("changed interpreter unexpectedly matched direct form")
+	}
+}
+
+func waitForProcessIdentity(t *testing.T, pid int) processIdentityInfo {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		identity, err := identifyProcess(pid)
+		if err == nil {
+			return identity
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	identity, err := identifyProcess(pid)
+	if err != nil {
+		t.Fatalf("identifyProcess(%d): %v", pid, err)
+	}
+	return identity
+}

--- a/internal/headroom/process_identity_unsupported.go
+++ b/internal/headroom/process_identity_unsupported.go
@@ -1,0 +1,23 @@
+//go:build !linux && !windows
+
+package headroom
+
+import (
+	"fmt"
+	"os"
+)
+
+type processIdentityInfo struct {
+	Executable string
+	Args       []string
+	Start      string
+}
+
+func processIdentitySupported() bool { return false }
+func identifyProcess(int) (processIdentityInfo, error) {
+	return processIdentityInfo{}, fmt.Errorf("process identity unavailable")
+}
+func killProcess(proc *os.Process) error {
+	return fmt.Errorf("process identity unavailable for pid %d", proc.Pid)
+}
+func processGone(*os.Process) bool { return false }

--- a/internal/headroom/process_identity_windows.go
+++ b/internal/headroom/process_identity_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package headroom
+
+import (
+	"fmt"
+	"os"
+)
+
+type processIdentityInfo struct {
+	Executable string
+	Args       []string
+	Start      string
+}
+
+func processIdentitySupported() bool { return false }
+
+func identifyProcess(int) (processIdentityInfo, error) {
+	return processIdentityInfo{}, fmt.Errorf("process identity unavailable")
+}
+func killProcess(proc *os.Process) error {
+	return fmt.Errorf("process identity unavailable for pid %d", proc.Pid)
+}
+func processGone(*os.Process) bool { return false }

--- a/internal/headroom/proxy.go
+++ b/internal/headroom/proxy.go
@@ -1,0 +1,240 @@
+package headroom
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+const (
+	proxyReadyTimeout = 15 * time.Second
+	proxyStopTimeout  = 5 * time.Second
+	proxyProbeTimeout = 2 * time.Second
+	proxyPollInterval = 300 * time.Millisecond
+)
+
+type proxyOwnership struct {
+	PID        int      `json:"pid"`
+	Executable string   `json:"executable"`
+	Args       []string `json:"args"`
+	Start      string   `json:"start_fingerprint"`
+}
+
+var (
+	proxyLiveZProbe = proxyLiveZ
+	proxySpawn      = spawnDetached
+	proxyIdentity   = identifyProcess
+	proxyKill       = killProcess
+	proxyWrite      = writeProxyOwnership
+	proxyGone       = processGone
+	proxyWait       = func(proc *os.Process) error { _, err := proc.Wait(); return err }
+	proxySleep      = time.Sleep
+	proxyNow        = time.Now
+)
+
+func ProxyPort() int         { return util.HeadroomProxyPort() }
+func ProxyURL() string       { return util.HeadroomProxyURL() }
+func ProxyOpenAIURL() string { return util.HeadroomProxyOpenAIURL() }
+
+func ProxyUpstreamURLs() (anthropic, openai string) {
+	anthropic, openai = "https://api.anthropic.com", "https://api.openai.com"
+	if v := strings.TrimSpace(os.Getenv("TOKLESS_HEADROOM_ANTHROPIC_URL")); v != "" {
+		anthropic = v
+	}
+	if v := strings.TrimSpace(os.Getenv("TOKLESS_HEADROOM_OPENAI_URL")); v != "" {
+		openai = v
+	}
+	return
+}
+
+func ResolveHeadroomBin() string {
+	if util.HeadroomInstalled() {
+		return util.HeadroomBin()
+	}
+	return util.Which("headroom")
+}
+
+func ProxyRunning() bool { return proxyLiveZProbe(proxyProbeTimeout) }
+
+func proxyLiveZ(timeout time.Duration) bool {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(ProxyURL() + "/livez")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	var live struct {
+		Service string `json:"service"`
+	}
+	return json.NewDecoder(resp.Body).Decode(&live) == nil && live.Service == "headroom-proxy"
+}
+
+func proxyFiles() (pidFile, logFile string) {
+	root := util.HeadroomPathsResolved().Root
+	return filepath.Join(root, "proxy.pid"), filepath.Join(root, "proxy.log")
+}
+
+func StartProxy() error {
+	if ProxyRunning() {
+		util.L.Sub("headroom proxy already running on " + ProxyURL())
+		return nil
+	}
+	bin := ResolveHeadroomBin()
+	if bin == "" {
+		return fmt.Errorf("headroom binary not found — install headroom first (run `tokless`)")
+	}
+	if !processIdentitySupported() {
+		return fmt.Errorf("headroom proxy lifecycle is unsupported on this platform: trustworthy process identity is unavailable")
+	}
+	port := ProxyPort()
+	anthropic, openai := ProxyUpstreamURLs()
+	args := []string{"proxy", "--port", strconv.Itoa(port), "--anthropic-api-url", anthropic, "--openai-api-url", openai}
+	pidFile, logFile := proxyFiles()
+	if err := util.EnsureDir(filepath.Dir(logFile)); err != nil {
+		return err
+	}
+	log, err := os.Create(logFile)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout, cmd.Stderr = log, log
+	if err := proxySpawn(cmd); err != nil {
+		_ = log.Close()
+		return fmt.Errorf("headroom proxy failed to start: %w", err)
+	}
+	_ = log.Close()
+	if cmd.Process == nil {
+		return fmt.Errorf("headroom proxy started without a process")
+	}
+	pid := cmd.Process.Pid
+	identity, err := proxyIdentity(pid)
+	if err != nil {
+		return rollbackProxy(cmd.Process, pidFile, fmt.Errorf("headroom proxy identity could not be verified: %w", err))
+	}
+	if !identity.matches(bin, args) {
+		return rollbackProxy(cmd.Process, pidFile, fmt.Errorf("headroom proxy identity could not be verified"))
+	}
+	if err := proxyWrite(pidFile, proxyOwnership{PID: pid, Executable: identity.Executable, Args: identity.Args, Start: identity.Start}); err != nil {
+		return rollbackProxy(cmd.Process, pidFile, fmt.Errorf("headroom proxy ownership record: %w", err))
+	}
+	util.L.Sub("headroom proxy on " + ProxyURL() + " (cache mode; log: " + logFile + ")")
+	deadline := proxyNow().Add(proxyReadyTimeout)
+	for proxyNow().Before(deadline) {
+		if proxyLiveZProbe(proxyProbeTimeout) {
+			util.L.Ok("headroom proxy ready")
+			return nil
+		}
+		proxySleep(proxyPollInterval)
+	}
+	return rollbackProxy(cmd.Process, pidFile, fmt.Errorf("headroom proxy did not become ready within %s — see %s", proxyReadyTimeout, logFile))
+}
+
+func StopProxy() error {
+	pidFile, _ := proxyFiles()
+	raw, ok := util.ReadFileSafe(pidFile)
+	if !ok {
+		return nil
+	}
+	var record proxyOwnership
+	if err := json.Unmarshal([]byte(raw), &record); err != nil || record.PID <= 0 || record.Executable == "" || len(record.Args) == 0 || record.Start == "" {
+		return fmt.Errorf("invalid proxy ownership record %s — refusing to stop", pidFile)
+	}
+	identity, err := proxyIdentity(record.PID)
+	if err != nil || !identity.matchesRecord(record) {
+		return fmt.Errorf("proxy pid %d identity could not be verified — refusing to stop", record.PID)
+	}
+	proc, err := os.FindProcess(record.PID)
+	if err != nil {
+		return fmt.Errorf("failed to find headroom proxy pid %d: %w", record.PID, err)
+	}
+	if err := proxyKill(proc); err != nil {
+		return fmt.Errorf("failed to stop headroom proxy pid %d: %w", record.PID, err)
+	}
+	deadline := proxyNow().Add(proxyStopTimeout)
+	for proxyNow().Before(deadline) {
+		if proxyGone(proc) && !proxyLiveZProbe(proxyProbeTimeout) {
+			if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("headroom proxy stopped but ownership record could not be removed: %w", err)
+			}
+			util.L.Ok("headroom proxy stopped")
+			return nil
+		}
+		proxySleep(proxyPollInterval)
+	}
+	return fmt.Errorf("headroom proxy did not stop (pid %d)", record.PID)
+}
+
+func (p processIdentityInfo) matches(executable string, args []string) bool {
+	want, err := normalizedExecutable(executable)
+	if err != nil {
+		return false
+	}
+	if p.Executable == want && equalStrings(p.Args, args) {
+		return true
+	}
+	if len(p.Args) == 0 || !equalStrings(p.Args[1:], args) {
+		return false
+	}
+	launcher, err := normalizedExecutable(p.Args[0])
+	return err == nil && launcher == want
+}
+func normalizedExecutable(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(path), nil
+}
+func (p processIdentityInfo) matchesRecord(r proxyOwnership) bool {
+	return p.Start == r.Start && p.Executable == r.Executable && equalStrings(p.Args, r.Args)
+}
+func (p processIdentityInfo) equal(other processIdentityInfo) bool {
+	return p.Start == other.Start && p.Executable == other.Executable && equalStrings(p.Args, other.Args)
+}
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+func writeProxyOwnership(path string, record proxyOwnership) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return writeProxyFileAtomic(path, data, 0o600)
+}
+
+func rollbackProxy(proc *os.Process, pidFile string, cause error) error {
+	if err := proxyKill(proc); err != nil {
+		return fmt.Errorf("%w; rollback kill for pid %d: %v", cause, proc.Pid, err)
+	}
+	if err := proxyWait(proc); err != nil {
+		return fmt.Errorf("%w; rollback wait for pid %d: %v", cause, proc.Pid, err)
+	}
+	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%w; rollback record removal: %v", cause, err)
+	}
+	return cause
+}

--- a/internal/headroom/proxy_persistence.go
+++ b/internal/headroom/proxy_persistence.go
@@ -1,0 +1,34 @@
+package headroom
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func writeProxyFileAtomic(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tokless-proxy-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return replaceProxyFile(tmpPath, path)
+}

--- a/internal/headroom/proxy_persistence_unix.go
+++ b/internal/headroom/proxy_persistence_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package headroom
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func replaceProxyFile(tmpPath, path string) error {
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/internal/headroom/proxy_persistence_windows.go
+++ b/internal/headroom/proxy_persistence_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package headroom
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	moveFileReplaceExisting = 0x00000001
+	moveFileWriteThrough    = 0x00000008
+)
+
+var (
+	replaceKernel32 = syscall.NewLazyDLL("kernel32.dll")
+	moveFileExProc  = replaceKernel32.NewProc("MoveFileExW")
+)
+
+func replaceProxyFile(tmpPath, path string) error {
+	from, err := syscall.UTF16PtrFromString(tmpPath)
+	if err != nil {
+		return err
+	}
+	to, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	r, _, callErr := moveFileExProc.Call(uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(to)), moveFileReplaceExisting|moveFileWriteThrough)
+	if r == 0 {
+		return callErr
+	}
+	return nil
+}

--- a/internal/headroom/proxy_test.go
+++ b/internal/headroom/proxy_test.go
@@ -1,0 +1,537 @@
+package headroom
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+func isolateProxyOps(t *testing.T) {
+	t.Helper()
+	oldProbe, oldSpawn := proxyLiveZProbe, proxySpawn
+	oldIdentity, oldKill := proxyIdentity, proxyKill
+	oldWrite, oldGone := proxyWrite, proxyGone
+	oldWait := proxyWait
+	oldSleep := proxySleep
+	oldNow := proxyNow
+	t.Cleanup(func() {
+		proxyLiveZProbe, proxySpawn = oldProbe, oldSpawn
+		proxyIdentity, proxyKill = oldIdentity, oldKill
+		proxyWrite, proxyGone = oldWrite, oldGone
+		proxyWait = oldWait
+		proxySleep = oldSleep
+		proxyNow = oldNow
+		util.SetHomeOverride("")
+	})
+}
+
+func proxyTestBin(t *testing.T) string {
+	t.Helper()
+	util.SetHomeOverride(t.TempDir())
+	bin := util.HeadroomBin()
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("test headroom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func TestProxyPortDefaults(t *testing.T) {
+	t.Setenv("TOKLESS_HEADROOM_PROXY_PORT", "")
+	if got := ProxyPort(); got != 8787 {
+		t.Fatalf("ProxyPort = %d, want 8787", got)
+	}
+	t.Setenv("TOKLESS_HEADROOM_PROXY_PORT", "9123")
+	if got := ProxyPort(); got != 9123 {
+		t.Fatalf("ProxyPort = %d, want 9123", got)
+	}
+	if got := ProxyURL(); got != "http://127.0.0.1:9123" {
+		t.Fatalf("ProxyURL = %q", got)
+	}
+}
+
+func TestProxyLiveZRejectsNonHeadroomService(t *testing.T) {
+	for _, service := range []string{"other-service", "", "headroom"} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"service":%q}`, service)
+		}))
+		port := server.Listener.Addr().(*net.TCPAddr).Port
+		t.Setenv("TOKLESS_HEADROOM_PROXY_PORT", fmt.Sprint(port))
+		want := service == "headroom-proxy"
+		if got := proxyLiveZ(1e9); got != want {
+			t.Fatalf("service %q: proxyLiveZ = %v, want %v", service, got, want)
+		}
+		server.Close()
+	}
+}
+
+func TestProxyOwnershipRecordIsJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proxy.pid")
+	if err := writeProxyOwnership(path, proxyOwnership{PID: 41, Executable: "/bin/old-headroom", Args: []string{"proxy"}, Start: "start-41"}); err != nil {
+		t.Fatal(err)
+	}
+	want := proxyOwnership{PID: 42, Executable: "/bin/headroom", Args: []string{"proxy", "--port", "8787"}, Start: "start-42"}
+	if err := writeProxyOwnership(path, want); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got proxyOwnership
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.PID != want.PID || got.Executable != want.Executable || !equalStrings(got.Args, want.Args) || got.Start != want.Start {
+		t.Fatalf("record = %+v, want %+v", got, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("ownership mode = %o, want 600", mode)
+	}
+}
+
+func TestProcessIdentityMatchesDirectInvocation(t *testing.T) {
+	bin := proxyTestBin(t)
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	args := []string{"proxy", "--port", "8787"}
+	identity := processIdentityInfo{Executable: bin, Args: args, Start: "start"}
+	if !identity.matches(bin, args) {
+		t.Fatal("direct executable invocation did not match")
+	}
+}
+
+func TestProcessIdentityMatchesPythonConsoleScript(t *testing.T) {
+	launcher := filepath.Join(t.TempDir(), "headroom")
+	if err := os.WriteFile(launcher, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"proxy", "--port", "8787"}
+	identity := processIdentityInfo{Executable: "/usr/bin/python3", Args: append([]string{launcher}, args...), Start: "start"}
+	if !identity.matches(launcher, args) {
+		t.Fatal("python console-script invocation did not match")
+	}
+}
+
+func TestProcessIdentityRejectsWrongConsoleScript(t *testing.T) {
+	launcher := filepath.Join(t.TempDir(), "headroom")
+	wrong := filepath.Join(t.TempDir(), "other")
+	for _, path := range []string{launcher, wrong} {
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	args := []string{"proxy", "--port", "8787"}
+	identity := processIdentityInfo{Executable: "/usr/bin/python3", Args: append([]string{wrong}, args...), Start: "start"}
+	if identity.matches(launcher, args) {
+		t.Fatal("wrong console script was accepted")
+	}
+}
+
+func TestProcessIdentityRecordRecheckRequiresExactIdentity(t *testing.T) {
+	record := proxyOwnership{PID: 42, Executable: "/usr/bin/python3", Args: []string{"headroom", "proxy"}, Start: "start"}
+	identity := processIdentityInfo{Executable: record.Executable, Args: append([]string(nil), record.Args...), Start: record.Start}
+	if !identity.matchesRecord(record) {
+		t.Fatal("exact identity did not match record")
+	}
+	for name, mutate := range map[string]func(*processIdentityInfo){
+		"changed interpreter": func(p *processIdentityInfo) { p.Executable = "/usr/bin/python3.12" },
+		"missing argument":    func(p *processIdentityInfo) { p.Args = p.Args[:1] },
+		"extra argument":      func(p *processIdentityInfo) { p.Args = append(p.Args, "extra") },
+		"reordered arguments": func(p *processIdentityInfo) {
+			p.Args[0], p.Args[1] = p.Args[1], p.Args[0]
+		},
+		"changed argument": func(p *processIdentityInfo) { p.Args[1] = "other" },
+		"changed start":    func(p *processIdentityInfo) { p.Start = "recycled-start" },
+	} {
+		changed := identity
+		changed.Args = append([]string(nil), identity.Args...)
+		mutate(&changed)
+		if changed.matchesRecord(record) {
+			t.Errorf("%s matched ownership record", name)
+		}
+	}
+}
+
+func TestRollbackProxyWaitFailureRetainsOwnershipRecord(t *testing.T) {
+	isolateProxyOps(t)
+	path := filepath.Join(t.TempDir(), "proxy.pid")
+	if err := writeProxyOwnership(path, proxyOwnership{PID: 4245, Executable: "/bin/headroom", Args: []string{"proxy"}, Start: "start"}); err != nil {
+		t.Fatal(err)
+	}
+	captured := processIdentityInfo{Executable: "/bin/headroom", Args: []string{"proxy"}, Start: "start"}
+	proxyIdentity = func(int) (processIdentityInfo, error) { return captured, nil }
+	proxyKill = func(*os.Process) error { return nil }
+	proxyWait = func(*os.Process) error { return errors.New("wait failed") }
+	now := time.Unix(100, 0)
+	proxyNow = func() time.Time { return now }
+	proxySleep = func(time.Duration) { now = now.Add(proxyStopTimeout) }
+
+	err := rollbackProxy(&os.Process{Pid: 4245}, path, errors.New("startup failed"))
+	if err == nil || !strings.Contains(err.Error(), "wait failed") {
+		t.Fatalf("rollbackProxy error = %v", err)
+	}
+	if _, ok := util.ReadFileSafe(path); !ok {
+		t.Fatal("ownership record removed after rollback timeout")
+	}
+}
+
+func TestRollbackProxyKillFailureSkipsWaitAndRetainsOwnershipRecord(t *testing.T) {
+	isolateProxyOps(t)
+	path := filepath.Join(t.TempDir(), "proxy.pid")
+	if err := writeProxyOwnership(path, proxyOwnership{PID: 4246, Executable: "/bin/headroom", Args: []string{"proxy"}, Start: "start"}); err != nil {
+		t.Fatal(err)
+	}
+	waited := false
+	proxyKill = func(*os.Process) error { return errors.New("kill failed") }
+	proxyWait = func(*os.Process) error { waited = true; return nil }
+
+	err := rollbackProxy(&os.Process{Pid: 4246}, path, errors.New("startup failed"))
+	if err == nil || !strings.Contains(err.Error(), "kill failed") {
+		t.Fatalf("rollbackProxy error = %v", err)
+	}
+	if waited {
+		t.Fatal("rollbackProxy waited after kill failure")
+	}
+	if _, ok := util.ReadFileSafe(path); !ok {
+		t.Fatal("ownership record removed after kill failure")
+	}
+}
+
+func TestStopProxyRefusesMismatchedIdentity(t *testing.T) {
+	isolateProxyOps(t)
+	bin := proxyTestBin(t)
+	pidFile, _ := proxyFiles()
+	record := proxyOwnership{PID: 4242, Executable: bin, Args: []string{"proxy"}, Start: "old-start"}
+	if err := writeProxyOwnership(pidFile, record); err != nil {
+		t.Fatal(err)
+	}
+	proxyIdentity = func(int) (processIdentityInfo, error) {
+		return processIdentityInfo{Executable: bin, Args: []string{"proxy"}, Start: "recycled-start"}, nil
+	}
+	killed := false
+	proxyKill = func(*os.Process) error { killed = true; return nil }
+	if err := StopProxy(); err == nil {
+		t.Fatal("StopProxy unexpectedly accepted recycled identity")
+	}
+	if killed {
+		t.Fatal("StopProxy killed mismatched process")
+	}
+	if _, ok := util.ReadFileSafe(pidFile); !ok {
+		t.Fatal("ownership record removed after identity mismatch")
+	}
+}
+
+func TestStopProxyRefusesUnavailableIdentity(t *testing.T) {
+	isolateProxyOps(t)
+	bin := proxyTestBin(t)
+	pidFile, _ := proxyFiles()
+	record := proxyOwnership{PID: 4243, Executable: bin, Args: []string{"proxy"}, Start: "start"}
+	if err := writeProxyOwnership(pidFile, record); err != nil {
+		t.Fatal(err)
+	}
+	proxyIdentity = func(int) (processIdentityInfo, error) { return processIdentityInfo{}, errors.New("unavailable") }
+	killed := false
+	proxyKill = func(*os.Process) error { killed = true; return nil }
+	if err := StopProxy(); err == nil {
+		t.Fatal("StopProxy unexpectedly accepted unavailable identity")
+	}
+	if killed {
+		t.Fatal("StopProxy killed unavailable process")
+	}
+	if _, ok := util.ReadFileSafe(pidFile); !ok {
+		t.Fatal("ownership record removed after unavailable identity")
+	}
+}
+
+func TestStopProxyTimeoutRetainsOwnershipRecord(t *testing.T) {
+	isolateProxyOps(t)
+	bin := proxyTestBin(t)
+	pidFile, _ := proxyFiles()
+	record := proxyOwnership{PID: 4244, Executable: bin, Args: []string{"proxy"}, Start: "start"}
+	if err := writeProxyOwnership(pidFile, record); err != nil {
+		t.Fatal(err)
+	}
+	proxyIdentity = func(int) (processIdentityInfo, error) {
+		return processIdentityInfo{Executable: bin, Args: []string{"proxy"}, Start: "start"}, nil
+	}
+	proxyKill = func(*os.Process) error { return nil }
+	proxyGone = func(*os.Process) bool { return false }
+	proxyLiveZProbe = func(time.Duration) bool { return false }
+	now := time.Unix(100, 0)
+	proxyNow = func() time.Time { return now }
+	proxySleep = func(time.Duration) { now = now.Add(proxyStopTimeout) }
+	if err := StopProxy(); err == nil || !strings.Contains(err.Error(), "did not stop") {
+		t.Fatalf("StopProxy error = %v", err)
+	}
+	if _, ok := util.ReadFileSafe(pidFile); !ok {
+		t.Fatal("ownership record removed after stop timeout")
+	}
+}
+
+func TestStartProxyRecordWriteFailureRollsBack(t *testing.T) {
+	isolateProxyOps(t)
+	bin := proxyTestBin(t)
+	proxyLiveZProbe = func(time.Duration) bool { return false }
+	proxySpawn = func(cmd *exec.Cmd) error { cmd.Process = &os.Process{Pid: 5252}; return nil }
+	proxyIdentity = func(int) (processIdentityInfo, error) {
+		return processIdentityInfo{Executable: bin, Args: []string{"proxy", "--port", "8787", "--anthropic-api-url", "https://api.anthropic.com", "--openai-api-url", "https://api.openai.com"}, Start: "start"}, nil
+	}
+	proxyWrite = func(string, proxyOwnership) error { return errors.New("disk full") }
+	proxyGone = func(*os.Process) bool { return true }
+	kills, waits := 0, 0
+	proxyKill = func(*os.Process) error { kills++; return nil }
+	proxyWait = func(*os.Process) error { waits++; return nil }
+	proxySleep = func(time.Duration) {}
+	if err := StartProxy(); err == nil || !strings.Contains(err.Error(), "ownership record") {
+		t.Fatalf("StartProxy error = %v", err)
+	}
+	if kills != 1 {
+		t.Fatalf("rollback kills = %d, want 1", kills)
+	}
+	if waits != 1 {
+		t.Fatalf("rollback waits = %d, want 1", waits)
+	}
+	pidFile, _ := proxyFiles()
+	if _, ok := util.ReadFileSafe(pidFile); ok {
+		t.Fatal("ownership record remains after rollback")
+	}
+}
+
+func TestStartProxyReadinessTimeoutRollsBack(t *testing.T) {
+	isolateProxyOps(t)
+	bin := proxyTestBin(t)
+	proxyLiveZProbe = func(time.Duration) bool { return false }
+	proxySpawn = func(cmd *exec.Cmd) error {
+		cmd.Process = &os.Process{Pid: 5253}
+		return nil
+	}
+	proxyIdentity = func(int) (processIdentityInfo, error) {
+		return processIdentityInfo{
+			Executable: bin,
+			Args:       []string{"proxy", "--port", "8787", "--anthropic-api-url", "https://api.anthropic.com", "--openai-api-url", "https://api.openai.com"},
+			Start:      "start",
+		}, nil
+	}
+	killed, waited := false, false
+	proxyKill = func(*os.Process) error {
+		killed = true
+		return nil
+	}
+	proxyWait = func(*os.Process) error { waited = true; return nil }
+	proxyGone = func(*os.Process) bool { return killed }
+	now := time.Unix(100, 0)
+	proxyNow = func() time.Time { return now }
+	proxySleep = func(time.Duration) { now = now.Add(proxyReadyTimeout) }
+
+	err := StartProxy()
+	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("StartProxy error = %v", err)
+	}
+	if !killed {
+		t.Fatal("readiness timeout did not kill child")
+	}
+	if !waited {
+		t.Fatal("readiness timeout did not wait for child")
+	}
+	pidFile, _ := proxyFiles()
+	if _, ok := util.ReadFileSafe(pidFile); ok {
+		t.Fatal("ownership record remains after readiness timeout rollback")
+	}
+}
+
+func TestStartProxyIdentityFailureRollsBackDirectChild(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity func(string) processIdentityInfo
+		wantErr  string
+	}{
+		{name: "lookup error", identity: func(string) processIdentityInfo { return processIdentityInfo{} }, wantErr: "identity lookup failed"},
+		{name: "mismatch", identity: func(bin string) processIdentityInfo {
+			return processIdentityInfo{Executable: bin, Args: []string{"proxy", "wrong"}, Start: "start"}
+		}, wantErr: "identity could not be verified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateProxyOps(t)
+			bin := proxyTestBin(t)
+			proxyLiveZProbe = func(time.Duration) bool { return false }
+			proxySpawn = func(cmd *exec.Cmd) error { cmd.Process = &os.Process{Pid: 5255}; return nil }
+			identityCalls := 0
+			proxyIdentity = func(int) (processIdentityInfo, error) {
+				identityCalls++
+				if tt.name == "lookup error" {
+					return processIdentityInfo{}, errors.New(tt.wantErr)
+				}
+				return tt.identity(bin), nil
+			}
+			killed, waited := false, false
+			proxyKill = func(*os.Process) error { killed = true; return nil }
+			proxyWait = func(*os.Process) error { waited = true; return nil }
+
+			err := StartProxy()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("StartProxy error = %v", err)
+			}
+			if !killed || !waited {
+				t.Fatalf("rollback kill=%v wait=%v, want both", killed, waited)
+			}
+			if identityCalls != 1 {
+				t.Fatalf("proxyIdentity calls = %d, want 1", identityCalls)
+			}
+			pidFile, _ := proxyFiles()
+			if _, ok := util.ReadFileSafe(pidFile); ok {
+				t.Fatal("ownership record remains after identity rollback")
+			}
+		})
+	}
+}
+
+func TestStartProxyReadinessRollbackIgnoresChangedIdentity(t *testing.T) {
+	isolateProxyOps(t)
+	bin := proxyTestBin(t)
+	proxyLiveZProbe = func(time.Duration) bool { return false }
+	proxySpawn = func(cmd *exec.Cmd) error {
+		cmd.Process = &os.Process{Pid: 5254}
+		return nil
+	}
+	args := []string{"proxy", "--port", "8787", "--anthropic-api-url", "https://api.anthropic.com", "--openai-api-url", "https://api.openai.com"}
+	launchIdentity := processIdentityInfo{Executable: bin, Args: args, Start: "start"}
+	identityCalls := 0
+	proxyIdentity = func(int) (processIdentityInfo, error) {
+		identityCalls++
+		return launchIdentity, nil
+	}
+	proxyWrite = func(path string, record proxyOwnership) error {
+		return writeProxyOwnership(path, record)
+	}
+	killed, waited := false, false
+	proxyKill = func(*os.Process) error {
+		killed = true
+		return nil
+	}
+	proxyWait = func(*os.Process) error { waited = true; return nil }
+	now := time.Unix(100, 0)
+	proxyNow = func() time.Time { return now }
+	proxySleep = func(time.Duration) { now = now.Add(proxyReadyTimeout) }
+
+	err := StartProxy()
+	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("StartProxy error = %v", err)
+	}
+	if !killed {
+		t.Fatal("readiness timeout did not kill child")
+	}
+	if !waited {
+		t.Fatal("changed-identity readiness timeout did not wait for child")
+	}
+	pidFile, _ := proxyFiles()
+	if _, ok := util.ReadFileSafe(pidFile); ok {
+		t.Fatal("ownership record remains after rollback")
+	}
+	if identityCalls != 1 {
+		t.Fatalf("proxyIdentity calls = %d, want 1", identityCalls)
+	}
+}
+
+func TestStartProxyReusesHeadroomProbe(t *testing.T) {
+	isolateProxyOps(t)
+	proxyTestBin(t)
+	proxyLiveZProbe = func(time.Duration) bool { return true }
+	spawned, wrote := false, false
+	proxySpawn = func(*exec.Cmd) error { spawned = true; return nil }
+	proxyWrite = func(string, proxyOwnership) error { wrote = true; return nil }
+	if err := StartProxy(); err != nil {
+		t.Fatal(err)
+	}
+	if spawned || wrote {
+		t.Fatalf("reused proxy spawned=%v wrote=%v", spawned, wrote)
+	}
+}
+
+func TestStartProxyDoesNotReuseNonHeadroomProbe(t *testing.T) {
+	isolateProxyOps(t)
+	proxyTestBin(t)
+	proxyLiveZProbe = func(time.Duration) bool { return false }
+	spawned := false
+	proxySpawn = func(cmd *exec.Cmd) error { spawned = true; cmd.Process = &os.Process{Pid: 5353}; return nil }
+	proxyIdentity = func(int) (processIdentityInfo, error) { return processIdentityInfo{}, errors.New("not headroom") }
+	proxyGone = func(*os.Process) bool { return true }
+	proxyKill = func(*os.Process) error { return nil }
+	if err := StartProxy(); err == nil {
+		t.Fatal("StartProxy reused non-headroom probe")
+	}
+	if !spawned {
+		t.Fatal("StartProxy did not attempt spawn after non-headroom probe")
+	}
+}
+
+func TestProxyPortIgnoresInvalidEnv(t *testing.T) {
+	for _, raw := range []string{"abc", "-1", "0", "70000", " 8a "} {
+		t.Setenv("TOKLESS_HEADROOM_PROXY_PORT", raw)
+		if got := ProxyPort(); got != 8787 {
+			t.Fatalf("ProxyPort(%q) = %d, want 8787", raw, got)
+		}
+	}
+}
+
+func TestProxyOpenAIURL(t *testing.T) {
+	t.Setenv("TOKLESS_HEADROOM_PROXY_PORT", "9123")
+	if got := ProxyOpenAIURL(); got != "http://127.0.0.1:9123/v1" {
+		t.Fatalf("ProxyOpenAIURL = %q, want http://127.0.0.1:9123/v1", got)
+	}
+}
+
+func TestProxyUpstreamURLsDefaultsAndEnv(t *testing.T) {
+	t.Setenv("TOKLESS_HEADROOM_ANTHROPIC_URL", "")
+	t.Setenv("TOKLESS_HEADROOM_OPENAI_URL", "")
+	a, o := ProxyUpstreamURLs()
+	if a != "https://api.anthropic.com" || o != "https://api.openai.com" {
+		t.Fatalf("defaults = %q, %q", a, o)
+	}
+	t.Setenv("TOKLESS_HEADROOM_ANTHROPIC_URL", "https://custom.anthropic")
+	t.Setenv("TOKLESS_HEADROOM_OPENAI_URL", "https://custom.openai/v1")
+	a, o = ProxyUpstreamURLs()
+	if a != "https://custom.anthropic" || o != "https://custom.openai/v1" {
+		t.Fatalf("overrides = %q, %q", a, o)
+	}
+}
+
+func TestResolveHeadroomBinPrefersManaged(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("TOKLESS_HEADROOM_PROXY_PORT", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	bin := util.HeadroomBin()
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("headroom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveHeadroomBin(); got != bin {
+		t.Fatalf("ResolveHeadroomBin = %q, want %q", got, bin)
+	}
+	_ = os.Remove(bin)
+	if got := ResolveHeadroomBin(); got != "" {
+		t.Fatalf("ResolveHeadroomBin without managed bin = %q, want empty", got)
+	}
+}

--- a/internal/headroom/spawn_detached_unix.go
+++ b/internal/headroom/spawn_detached_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package headroom
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// spawnDetached starts cmd in a new session so the parent can exit without
+// tearing the daemon down.
+func spawnDetached(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd.Start()
+}

--- a/internal/headroom/spawn_detached_windows.go
+++ b/internal/headroom/spawn_detached_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package headroom
+
+import "os/exec"
+
+// spawnDetached starts cmd independently.
+func spawnDetached(cmd *exec.Cmd) error {
+	return cmd.Start()
+}

--- a/internal/tools/autoindex_test.go
+++ b/internal/tools/autoindex_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestClaudeAutoIndexUnwireKeepsUserHook(t *testing.T) {
 	dir := t.TempDir()
-	os.Setenv("HOME", dir)
-	defer os.Unsetenv("HOME")
+	t.Setenv("HOME", dir)
 	util.SetHomeOverride(dir)
 	defer util.SetHomeOverride("")
 	cp := util.ClaudeCodePaths()
@@ -35,8 +34,7 @@ func TestClaudeAutoIndexUnwireKeepsUserHook(t *testing.T) {
 
 func TestGeminiAutoIndexUnwireKeepsUserHook(t *testing.T) {
 	dir := t.TempDir()
-	os.Setenv("HOME", dir)
-	defer os.Unsetenv("HOME")
+	t.Setenv("HOME", dir)
 	util.SetHomeOverride(dir)
 	defer util.SetHomeOverride("")
 	p := geminiSettingsPath()
@@ -58,8 +56,7 @@ func TestGeminiAutoIndexUnwireKeepsUserHook(t *testing.T) {
 
 func TestCodexAutoIndexUnwireKeepsContextMode(t *testing.T) {
 	dir := t.TempDir()
-	os.Setenv("CODEX_HOME", dir)
-	defer os.Unsetenv("CODEX_HOME")
+	t.Setenv("CODEX_HOME", dir)
 	hp := filepath.Join(dir, "hooks.json")
 	os.WriteFile(hp, []byte(`{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"context-mode hook codex sessionstart"}]},{"matcher":"startup","hooks":[{"type":"command","command":"tokless index --auto --agent codex"}]}]}}`), 0o644)
 

--- a/internal/tools/cline_test.go
+++ b/internal/tools/cline_test.go
@@ -175,13 +175,27 @@ func buildClineSimBinary(t *testing.T) string {
 	}
 	build := exec.Command("go", "build", "-o", bin, "./cmd/tokless")
 	build.Dir = root
+	goHome := t.TempDir()
+	cacheEnv, err := exec.Command("go", "env", "GOPATH", "GOMODCACHE").Output()
+	if err != nil {
+		t.Fatalf("go env cache paths: %v", err)
+	}
+	cachePaths := strings.Fields(string(cacheEnv))
+	if len(cachePaths) != 2 || cachePaths[0] == "" || cachePaths[1] == "" {
+		t.Fatalf("go env cache paths = %q", cacheEnv)
+	}
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "GOCACHE=") {
+		if !strings.HasPrefix(e, "HOME=") && !strings.HasPrefix(e, "GOCACHE=") && !strings.HasPrefix(e, "GOPATH=") && !strings.HasPrefix(e, "GOMODCACHE=") {
 			env = append(env, e)
 		}
 	}
-	build.Env = append(env, "GOCACHE="+filepath.Join(t.TempDir(), "gocache"))
+	build.Env = append(env,
+		"HOME="+goHome,
+		"GOCACHE="+filepath.Join(goHome, "gocache"),
+		"GOPATH="+cachePaths[0],
+		"GOMODCACHE="+cachePaths[1],
+	)
 	out, err := build.CombinedOutput()
 	if err != nil {
 		t.Fatalf("go build tokless: %v\n%s", err, out)

--- a/internal/tools/contextmode.go
+++ b/internal/tools/contextmode.go
@@ -810,6 +810,7 @@ func Register() {
 	core.RegisterTool(caveman)
 	core.RegisterTool(codegraph)
 	core.RegisterTool(contextMode)
+	core.RegisterTool(headroom)
 	core.RegisterTool(ponytail)
 }
 

--- a/internal/tools/headroom.go
+++ b/internal/tools/headroom.go
@@ -1,0 +1,432 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/HoangP8/tokless/internal/agents"
+	"github.com/HoangP8/tokless/internal/core"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+const headroomPackage = "headroom-ai[mcp]"
+
+const headroomProbeTimeout = 500 * time.Millisecond
+
+var runHeadroom = func(command string, args, env []string, ctx context.Context) util.ExecResult {
+	return util.Run(command, args, util.RunOptions{Capture: true, Env: env, Ctx: ctx})
+}
+
+func headroomInstallArgs(upgrade bool) []string {
+	args := []string{"tool", "install"}
+	if upgrade {
+		args = append(args, "--upgrade")
+	}
+	return append(args, "--python", "3.13", headroomPackage)
+}
+
+func headroomPythonInstallArgs() []string { return []string{"python", "install", "3.13"} }
+
+func headroomNativeBuildRisk() bool {
+	return headroomNativeBuildRiskFor(runtime.GOOS, runtime.GOARCH)
+}
+
+func headroomNativeBuildRiskFor(goos, goarch string) bool {
+	return goos == "windows" || goos == "darwin" && goarch == "amd64"
+}
+
+func headroomFailure(stage string, result util.ExecResult) error {
+	hint := ""
+	if headroomNativeBuildRisk() {
+		hint = " Rust/native toolchain may be required on this platform. Manual: " + strings.Join(append([]string{util.HeadroomPathsResolved().UV}, headroomInstallArgs(false)...), " ")
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail != "" {
+		detail = ": " + strings.Split(detail, "\n")[0]
+	}
+	return fmt.Errorf("headroom %s failed%s%s", stage, detail, hint)
+}
+
+func headroomUV() (string, error) {
+	p := util.HeadroomPathsResolved()
+	if util.Exists(p.UV) && headroomUVWorks(p.UV) {
+		return p.UV, nil
+	}
+	if system := util.Which("uv"); system != "" && headroomUVWorks(system) {
+		return system, nil
+	}
+	if err := util.EnsureDir(filepath.Dir(p.UV)); err != nil {
+		return "", err
+	}
+	var command string
+	var args []string
+	if util.IsWin {
+		command = "powershell"
+		args = []string{"-ExecutionPolicy", "ByPass", "-c", "$env:UV_INSTALL_DIR=$env:TOKLESS_HEADROOM_UV_INSTALL_DIR;$env:UV_NO_MODIFY_PATH=1;irm https://astral.sh/uv/install.ps1 | iex"}
+	} else {
+		command = "sh"
+		args = []string{"-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"}
+	}
+	env := append(util.HeadroomUVBootstrapEnv(), "TOKLESS_HEADROOM_UV_INSTALL_DIR="+filepath.Dir(p.UV))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := runHeadroom(command, args, env, ctx)
+	if result.Code != 0 || !util.Exists(p.UV) || !headroomUVWorks(p.UV) {
+		return "", headroomFailure("uv bootstrap", result)
+	}
+	return p.UV, nil
+}
+
+func headroomUVWorks(uv string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return runHeadroom(uv, []string{"--version"}, util.HeadroomEnv(), ctx).Code == 0
+}
+
+func headroomServeProbe() error {
+	ctx, cancel := context.WithTimeout(context.Background(), headroomProbeTimeout)
+	defer cancel()
+	started := time.Now()
+	result := runHeadroom(util.HeadroomBin(), []string{"mcp", "serve"}, nil, ctx)
+	if ctx.Err() == context.DeadlineExceeded && time.Since(started) >= headroomProbeTimeout {
+		return nil
+	}
+	return headroomFailure("executable verification", result)
+}
+
+func headroomEnsureInstalled(opts core.RunOpts) (bool, error) {
+	if isTest() {
+		return true, nil
+	}
+	if opts.DryRun {
+		util.L.Sub("[dry-run] would install headroom-ai[mcp] with managed Python 3.13")
+		return true, nil
+	}
+	opts.Reportf("uv bootstrap", 0.1)
+	uv, err := headroomUV()
+	if err != nil {
+		return false, err
+	}
+	if util.HeadroomInstalled() && !opts.Upgrade {
+		if err := headroomServeProbe(); err != nil {
+			return false, err
+		}
+		opts.Reportf("already installed", 1)
+		return true, nil
+	}
+	opts.Reportf("managed Python", 0.3)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	if result := runHeadroom(uv, headroomPythonInstallArgs(), util.HeadroomEnv(), ctx); result.Code != 0 {
+		return false, headroomFailure("managed Python", result)
+	}
+	opts.Reportf("package install", 0.5)
+	result := runHeadroom(uv, headroomInstallArgs(opts.Upgrade), util.HeadroomEnv(), ctx)
+	if result.Code != 0 {
+		return false, headroomFailure("package install", result)
+	}
+	if !util.HeadroomInstalled() {
+		return false, fmt.Errorf("headroom executable verification failed: %s", util.HeadroomBin())
+	}
+	if err := headroomServeProbe(); err != nil {
+		return false, err
+	}
+	opts.Reportf("ready", 1)
+	return true, nil
+}
+
+func headroomWire(agent string) core.AgentFn {
+	return func(opts core.RunOpts) (bool, error) {
+		if opts.DryRun {
+			return true, nil
+		}
+		if !headroomCanConfigure(agent) {
+			return false, fmt.Errorf("%s already has a non-Tokless headroom MCP entry; refusing to overwrite it", agent)
+		}
+		if !headroomConfigureMcp(agent) && !headroomMcpMatches(agent) {
+			return false, nil
+		}
+		if agent != "cursor" {
+			if agent == "kilo" {
+				kiloWriteOwner("headroom")
+			} else {
+				WriteOwner(agent, "headroom")
+			}
+		}
+		if agent == "copilot" {
+			agents.ConfigureCopilotIdeMcp("headroom")
+			agents.SyncCopilotIdeInstructions()
+		}
+		return headroomVerify(agent), nil
+	}
+}
+
+func headroomConfigureMcp(agent string) bool {
+	switch agent {
+	case "claude":
+		agents.ConfigureClaudeMcp("headroom")
+		return true
+	case "opencode":
+		agents.ConfigureOpenCodeMcp("headroom")
+		return true
+	case "codex":
+		agents.ConfigureCodexMcp("headroom")
+		return true
+	case "cursor":
+		changed, _ := agents.ConfigureCursorMcp("headroom")
+		return changed || agents.CursorMcpHas("headroom")
+	case "antigravity":
+		agents.ConfigureAntigravityMcp("headroom")
+		return true
+	case "copilot":
+		agents.ConfigureCopilotMcp("headroom")
+		return true
+	case "droid":
+		agents.ConfigureDroidMcp("headroom")
+		return true
+	case "grok":
+		_, _, err := agents.ConfigureGrokMcp("headroom")
+		return err == nil
+	case "pi":
+		agents.ConfigurePiMcp("headroom")
+		return true
+	case "omp":
+		changed, _ := agents.ConfigureOmpMcp("headroom")
+		return changed || agents.OmpMcpHas("headroom")
+	case "kilo":
+		spawn := util.McpSpawnFor("headroom")
+		_, _, err := agents.ConfigureKiloMcpSafe("headroom", append([]string{spawn.Command}, spawn.Args...))
+		return err == nil
+	case "cline":
+		spawn := util.McpSpawnFor("headroom")
+		_, _, err := agents.ConfigureClineMcpSafe("headroom", append([]string{spawn.Command}, spawn.Args...))
+		return err == nil
+	}
+	return false
+}
+
+func headroomUnwire(agent string) core.AgentFn {
+	return func(opts core.RunOpts) (bool, error) {
+		if opts.DryRun {
+			return true, nil
+		}
+		owned := HasOwner(agent, "headroom")
+		if agent == "kilo" {
+			owned = kiloHasOwner("headroom")
+		}
+		if agent != "cursor" && (!owned || !headroomMcpMatches(agent)) {
+			return false, nil
+		}
+		switch agent {
+		case "claude":
+			agents.RemoveClaudeMcp("headroom")
+		case "opencode":
+			agents.RemoveOpenCodeMcp("headroom")
+		case "codex":
+			p := util.CodexPathsResolved().Config
+			raw, ok := util.ReadFileSafe(p)
+			if ok {
+				_ = util.WriteFile(p, util.RemoveBlock(raw, "mcp_servers.headroom"))
+			}
+		case "cursor":
+			agents.RemoveCursorMcp("headroom")
+		case "antigravity":
+			agents.RemoveAntigravityMcp("headroom")
+		case "copilot":
+			agents.RemoveCopilotMcp("headroom")
+			agents.RemoveCopilotIdeMcp("headroom")
+		case "droid":
+			agents.RemoveDroidMcp("headroom")
+		case "grok":
+			if _, err := agents.RemoveGrokMcp("headroom"); err != nil {
+				return false, err
+			}
+		case "pi":
+			agents.RemovePiMcp("headroom")
+		case "omp":
+			agents.RemoveOmpMcp("headroom")
+		case "kilo":
+			agents.RemoveKiloMcp("headroom")
+		case "cline":
+			agents.RemoveClineMcp("headroom")
+		}
+		if agent == "kilo" {
+			kiloRemoveOwner("headroom")
+		} else if agent != "cursor" {
+			RemoveOwner(agent, "headroom")
+		}
+		return true, nil
+	}
+}
+
+func headroomVerify(agent string) bool {
+	if !isTest() && !util.HeadroomInstalled() {
+		return false
+	}
+	switch agent {
+	case "claude":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "opencode":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "codex":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "cursor":
+		return headroomMcpMatches(agent)
+	case "antigravity":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "copilot":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "droid":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "grok":
+		return agents.GrokHeadroomMcpHas() && HasOwner(agent, "headroom")
+	case "pi":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "omp":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	case "kilo":
+		return headroomMcpMatches(agent) && kiloHasOwner("headroom")
+	case "cline":
+		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
+	}
+	return false
+}
+
+func headroomCanConfigure(agent string) bool {
+	found, matches := headroomMcpState(agent)
+	return !found || matches
+}
+
+func headroomMcpMatches(agent string) bool {
+	found, matches := headroomMcpState(agent)
+	return found && matches
+}
+
+func headroomMcpState(agent string) (found, matches bool) {
+	spawn := util.McpSpawnFor("headroom")
+	command := append([]string{spawn.Command}, spawn.Args...)
+	switch agent {
+	case "claude":
+		return headroomJSONEntry(util.ClaudeCodePaths().GlobalJSON, "mcpServers", headroomStdioEntry(spawn))
+	case "opencode":
+		entry := util.NewOrderedMap()
+		entry.Set("type", "local")
+		entry.Set("command", toAny(command))
+		entry.Set("enabled", true)
+		return headroomJSONEntry(util.OpenCodePathsResolved().Config, "mcp", entry)
+	case "codex":
+		raw, _ := util.ReadFileSafe(util.CodexPathsResolved().Config)
+		if !util.HasBlock(raw, "mcp_servers.headroom") {
+			return false, false
+		}
+		entry := util.NewTomlBlock("mcp_servers.headroom")
+		entry.Set("command", spawn.Command)
+		entry.Set("args", spawn.Args)
+		entry.Set("enabled", true)
+		entry.Set("default_tools_approval_mode", "approve")
+		return true, util.UpsertBlock(raw, entry, false) == raw
+	case "cursor":
+		return headroomJSONEntry(util.CursorGlobalMcpPath(), "mcpServers", headroomStdioEntry(spawn))
+	case "antigravity":
+		entry := util.NewOrderedMap()
+		entry.Set("command", spawn.Command)
+		entry.Set("args", toAny(spawn.Args))
+		entry.Set("trust", true)
+		return headroomJSONEntries([]string{util.AntigravityPathsResolved().McpConfigCLI, filepath.Join(util.Home(), ".gemini", "antigravity-cli", "mcp_config.json")}, "mcpServers", entry)
+	case "copilot":
+		cli := util.NewOrderedMap()
+		cli.Set("type", "local")
+		cli.Set("command", spawn.Command)
+		cli.Set("args", toAny(spawn.Args))
+		cli.Set("tools", []any{"*"})
+		ide := headroomStdioEntry(spawn)
+		foundCLI, matchesCLI := headroomJSONEntry(util.CopilotPathsResolved().McpConfig, "mcpServers", cli)
+		foundIDE, matchesIDE := headroomJSONEntry(filepath.Join(agents.IdeProjectRoot(), ".vscode", "mcp.json"), "servers", ide)
+		return foundCLI || foundIDE, foundCLI && matchesCLI && foundIDE && matchesIDE
+	case "droid":
+		entry := util.NewOrderedMap()
+		entry.Set("command", spawn.Command)
+		entry.Set("args", toAny(spawn.Args))
+		entry.Set("enabledTools", toAny(agents.HeadroomDroidToolNames))
+		return headroomJSONEntry(filepath.Join(util.Home(), ".factory", "mcp.json"), "mcpServers", entry)
+	case "grok":
+		return agents.GrokHeadroomMcpHas(), agents.GrokHeadroomMcpHas()
+	case "pi":
+		entry := util.NewOrderedMap()
+		entry.Set("command", spawn.Command)
+		entry.Set("args", toAny(spawn.Args))
+		entry.Set("lifecycle", "lazy")
+		entry.Set("directTools", true)
+		return headroomJSONEntry(filepath.Join(agents.PiAgentDirResolved(), "mcp.json"), "mcpServers", entry)
+	case "omp":
+		return agents.OmpMcpHas("headroom"), agents.OmpMcpHas("headroom")
+	case "kilo":
+		return agents.KiloMcpConfigured("headroom"), agents.KiloMcpMatches("headroom", command)
+	case "cline":
+		return agents.ClineMcpConfigured("headroom"), agents.ClineMcpMatches("headroom", command)
+	}
+	return false, false
+}
+
+func headroomStdioEntry(spawn util.McpSpawn) *util.OrderedMap {
+	entry := util.NewOrderedMap()
+	entry.Set("type", "stdio")
+	entry.Set("command", spawn.Command)
+	entry.Set("args", toAny(spawn.Args))
+	return entry
+}
+
+func headroomJSONEntries(paths []string, key string, expected *util.OrderedMap) (found, matches bool) {
+	matches = true
+	for _, path := range paths {
+		seen, same := headroomJSONEntry(path, key, expected)
+		if seen {
+			found = true
+			matches = matches && same
+		}
+	}
+	return found, matches
+}
+
+func headroomJSONEntry(path, key string, expected *util.OrderedMap) (found, matches bool) {
+	raw, ok := util.ReadFileSafe(path)
+	if !ok {
+		return false, false
+	}
+	cfg := util.TryParseJsonc(raw)
+	if cfg == nil {
+		return false, false
+	}
+	v, ok := cfg.Get(key)
+	if !ok {
+		return false, false
+	}
+	m, ok := v.(*util.OrderedMap)
+	if !ok {
+		return false, false
+	}
+	entry, found := m.Get("headroom")
+	return found, found && util.StringifyJSON(entry) == util.StringifyJSON(expected)
+}
+
+var headroom = &core.ToolManifest{
+	ID: "headroom", Label: "Headroom", Description: "On-demand MCP compression for large, self-contained text.",
+	Homepage: "https://github.com/headroomlabs-ai/headroom", InstallHint: "Tokless-managed uv tool: headroom-ai[mcp] (Python 3.13).",
+	Channel: core.ChannelBinary, NotTrackable: true, Install: headroomEnsureInstalled,
+	WireFor: map[string]core.AgentFn{}, UnwireFor: map[string]core.AgentFn{}, VerifyFor: map[string]core.VerifyFn{},
+}
+
+func init() {
+	for _, agent := range []string{"claude", "opencode", "codex", "cursor", "antigravity", "copilot", "droid", "grok", "pi", "omp", "kilo", "cline"} {
+		headroom.WireFor[agent] = headroomWire(agent)
+		headroom.UnwireFor[agent] = headroomUnwire(agent)
+		headroom.VerifyFor[agent] = func(agent string) core.VerifyFn { return func() *bool { return core.BoolPtr(headroomVerify(agent)) } }(agent)
+	}
+}

--- a/internal/tools/headroom.go
+++ b/internal/tools/headroom.go
@@ -1,156 +1,23 @@
 package tools
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"time"
 
 	"github.com/HoangP8/tokless/internal/agents"
 	"github.com/HoangP8/tokless/internal/core"
+	headroompkg "github.com/HoangP8/tokless/internal/headroom"
 	"github.com/HoangP8/tokless/internal/util"
 )
-
-const headroomPackage = "headroom-ai[mcp]"
-
-const headroomProbeTimeout = 500 * time.Millisecond
-
-var runHeadroom = func(command string, args, env []string, ctx context.Context) util.ExecResult {
-	return util.Run(command, args, util.RunOptions{Capture: true, Env: env, Ctx: ctx})
-}
-
-func headroomInstallArgs(upgrade bool) []string {
-	args := []string{"tool", "install"}
-	if upgrade {
-		args = append(args, "--upgrade")
-	}
-	return append(args, "--python", "3.13", headroomPackage)
-}
-
-func headroomPythonInstallArgs() []string { return []string{"python", "install", "3.13"} }
-
-func headroomNativeBuildRisk() bool {
-	return headroomNativeBuildRiskFor(runtime.GOOS, runtime.GOARCH)
-}
-
-func headroomNativeBuildRiskFor(goos, goarch string) bool {
-	return goos == "windows" || goos == "darwin" && goarch == "amd64"
-}
-
-func headroomFailure(stage string, result util.ExecResult) error {
-	hint := ""
-	if headroomNativeBuildRisk() {
-		hint = " Rust/native toolchain may be required on this platform. Manual: " + strings.Join(append([]string{util.HeadroomPathsResolved().UV}, headroomInstallArgs(false)...), " ")
-	}
-	detail := strings.TrimSpace(result.Stderr)
-	if detail == "" {
-		detail = strings.TrimSpace(result.Stdout)
-	}
-	if detail != "" {
-		detail = ": " + strings.Split(detail, "\n")[0]
-	}
-	return fmt.Errorf("headroom %s failed%s%s", stage, detail, hint)
-}
-
-func headroomUV() (string, error) {
-	p := util.HeadroomPathsResolved()
-	if util.Exists(p.UV) && headroomUVWorks(p.UV) {
-		return p.UV, nil
-	}
-	if system := util.Which("uv"); system != "" && headroomUVWorks(system) {
-		return system, nil
-	}
-	if err := util.EnsureDir(filepath.Dir(p.UV)); err != nil {
-		return "", err
-	}
-	var command string
-	var args []string
-	if util.IsWin {
-		command = "powershell"
-		args = []string{"-ExecutionPolicy", "ByPass", "-c", "$env:UV_INSTALL_DIR=$env:TOKLESS_HEADROOM_UV_INSTALL_DIR;$env:UV_NO_MODIFY_PATH=1;irm https://astral.sh/uv/install.ps1 | iex"}
-	} else {
-		command = "sh"
-		args = []string{"-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"}
-	}
-	env := append(util.HeadroomUVBootstrapEnv(), "TOKLESS_HEADROOM_UV_INSTALL_DIR="+filepath.Dir(p.UV))
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-	result := runHeadroom(command, args, env, ctx)
-	if result.Code != 0 || !util.Exists(p.UV) || !headroomUVWorks(p.UV) {
-		return "", headroomFailure("uv bootstrap", result)
-	}
-	return p.UV, nil
-}
-
-func headroomUVWorks(uv string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	return runHeadroom(uv, []string{"--version"}, util.HeadroomEnv(), ctx).Code == 0
-}
-
-func headroomServeProbe() error {
-	ctx, cancel := context.WithTimeout(context.Background(), headroomProbeTimeout)
-	defer cancel()
-	started := time.Now()
-	result := runHeadroom(util.HeadroomBin(), []string{"mcp", "serve"}, nil, ctx)
-	if ctx.Err() == context.DeadlineExceeded && time.Since(started) >= headroomProbeTimeout {
-		return nil
-	}
-	return headroomFailure("executable verification", result)
-}
-
-func headroomEnsureInstalled(opts core.RunOpts) (bool, error) {
-	if isTest() {
-		return true, nil
-	}
-	if opts.DryRun {
-		util.L.Sub("[dry-run] would install headroom-ai[mcp] with managed Python 3.13")
-		return true, nil
-	}
-	opts.Reportf("uv bootstrap", 0.1)
-	uv, err := headroomUV()
-	if err != nil {
-		return false, err
-	}
-	if util.HeadroomInstalled() && !opts.Upgrade {
-		if err := headroomServeProbe(); err != nil {
-			return false, err
-		}
-		opts.Reportf("already installed", 1)
-		return true, nil
-	}
-	opts.Reportf("managed Python", 0.3)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer cancel()
-	if result := runHeadroom(uv, headroomPythonInstallArgs(), util.HeadroomEnv(), ctx); result.Code != 0 {
-		return false, headroomFailure("managed Python", result)
-	}
-	opts.Reportf("package install", 0.5)
-	result := runHeadroom(uv, headroomInstallArgs(opts.Upgrade), util.HeadroomEnv(), ctx)
-	if result.Code != 0 {
-		return false, headroomFailure("package install", result)
-	}
-	if !util.HeadroomInstalled() {
-		return false, fmt.Errorf("headroom executable verification failed: %s", util.HeadroomBin())
-	}
-	if err := headroomServeProbe(); err != nil {
-		return false, err
-	}
-	opts.Reportf("ready", 1)
-	return true, nil
-}
 
 func headroomWire(agent string) core.AgentFn {
 	return func(opts core.RunOpts) (bool, error) {
 		if opts.DryRun {
 			return true, nil
 		}
-		if !headroomCanConfigure(agent) {
+		if !headroompkg.CanConfigure(agent) {
 			return false, fmt.Errorf("%s already has a non-Tokless headroom MCP entry; refusing to overwrite it", agent)
 		}
-		if !headroomConfigureMcp(agent) && !headroomMcpMatches(agent) {
+		if !headroompkg.ConfigureMcp(agent) && !headroompkg.McpMatches(agent) {
 			return false, nil
 		}
 		if agent != "cursor" {
@@ -168,50 +35,6 @@ func headroomWire(agent string) core.AgentFn {
 	}
 }
 
-func headroomConfigureMcp(agent string) bool {
-	switch agent {
-	case "claude":
-		agents.ConfigureClaudeMcp("headroom")
-		return true
-	case "opencode":
-		agents.ConfigureOpenCodeMcp("headroom")
-		return true
-	case "codex":
-		agents.ConfigureCodexMcp("headroom")
-		return true
-	case "cursor":
-		changed, _ := agents.ConfigureCursorMcp("headroom")
-		return changed || agents.CursorMcpHas("headroom")
-	case "antigravity":
-		agents.ConfigureAntigravityMcp("headroom")
-		return true
-	case "copilot":
-		agents.ConfigureCopilotMcp("headroom")
-		return true
-	case "droid":
-		agents.ConfigureDroidMcp("headroom")
-		return true
-	case "grok":
-		_, _, err := agents.ConfigureGrokMcp("headroom")
-		return err == nil
-	case "pi":
-		agents.ConfigurePiMcp("headroom")
-		return true
-	case "omp":
-		changed, _ := agents.ConfigureOmpMcp("headroom")
-		return changed || agents.OmpMcpHas("headroom")
-	case "kilo":
-		spawn := util.McpSpawnFor("headroom")
-		_, _, err := agents.ConfigureKiloMcpSafe("headroom", append([]string{spawn.Command}, spawn.Args...))
-		return err == nil
-	case "cline":
-		spawn := util.McpSpawnFor("headroom")
-		_, _, err := agents.ConfigureClineMcpSafe("headroom", append([]string{spawn.Command}, spawn.Args...))
-		return err == nil
-	}
-	return false
-}
-
 func headroomUnwire(agent string) core.AgentFn {
 	return func(opts core.RunOpts) (bool, error) {
 		if opts.DryRun {
@@ -221,7 +44,7 @@ func headroomUnwire(agent string) core.AgentFn {
 		if agent == "kilo" {
 			owned = kiloHasOwner("headroom")
 		}
-		if agent != "cursor" && (!owned || !headroomMcpMatches(agent)) {
+		if agent != "cursor" && (!owned || !headroompkg.McpMatches(agent)) {
 			return false, nil
 		}
 		switch agent {
@@ -231,8 +54,7 @@ func headroomUnwire(agent string) core.AgentFn {
 			agents.RemoveOpenCodeMcp("headroom")
 		case "codex":
 			p := util.CodexPathsResolved().Config
-			raw, ok := util.ReadFileSafe(p)
-			if ok {
+			if raw, ok := util.ReadFileSafe(p); ok {
 				_ = util.WriteFile(p, util.RemoveBlock(raw, "mcp_servers.headroom"))
 			}
 		case "cursor":
@@ -270,156 +92,22 @@ func headroomVerify(agent string) bool {
 	if !isTest() && !util.HeadroomInstalled() {
 		return false
 	}
-	switch agent {
-	case "claude":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "opencode":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "codex":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "cursor":
-		return headroomMcpMatches(agent)
-	case "antigravity":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "copilot":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "droid":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "grok":
+	if agent == "cursor" {
+		return headroompkg.McpMatches(agent)
+	}
+	if agent == "kilo" {
+		return headroompkg.McpMatches(agent) && kiloHasOwner("headroom")
+	}
+	if agent == "grok" {
 		return agents.GrokHeadroomMcpHas() && HasOwner(agent, "headroom")
-	case "pi":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "omp":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
-	case "kilo":
-		return headroomMcpMatches(agent) && kiloHasOwner("headroom")
-	case "cline":
-		return headroomMcpMatches(agent) && HasOwner(agent, "headroom")
 	}
-	return false
-}
-
-func headroomCanConfigure(agent string) bool {
-	found, matches := headroomMcpState(agent)
-	return !found || matches
-}
-
-func headroomMcpMatches(agent string) bool {
-	found, matches := headroomMcpState(agent)
-	return found && matches
-}
-
-func headroomMcpState(agent string) (found, matches bool) {
-	spawn := util.McpSpawnFor("headroom")
-	command := append([]string{spawn.Command}, spawn.Args...)
-	switch agent {
-	case "claude":
-		return headroomJSONEntry(util.ClaudeCodePaths().GlobalJSON, "mcpServers", headroomStdioEntry(spawn))
-	case "opencode":
-		entry := util.NewOrderedMap()
-		entry.Set("type", "local")
-		entry.Set("command", toAny(command))
-		entry.Set("enabled", true)
-		return headroomJSONEntry(util.OpenCodePathsResolved().Config, "mcp", entry)
-	case "codex":
-		raw, _ := util.ReadFileSafe(util.CodexPathsResolved().Config)
-		if !util.HasBlock(raw, "mcp_servers.headroom") {
-			return false, false
-		}
-		entry := util.NewTomlBlock("mcp_servers.headroom")
-		entry.Set("command", spawn.Command)
-		entry.Set("args", spawn.Args)
-		entry.Set("enabled", true)
-		entry.Set("default_tools_approval_mode", "approve")
-		return true, util.UpsertBlock(raw, entry, false) == raw
-	case "cursor":
-		return headroomJSONEntry(util.CursorGlobalMcpPath(), "mcpServers", headroomStdioEntry(spawn))
-	case "antigravity":
-		entry := util.NewOrderedMap()
-		entry.Set("command", spawn.Command)
-		entry.Set("args", toAny(spawn.Args))
-		entry.Set("trust", true)
-		return headroomJSONEntries([]string{util.AntigravityPathsResolved().McpConfigCLI, filepath.Join(util.Home(), ".gemini", "antigravity-cli", "mcp_config.json")}, "mcpServers", entry)
-	case "copilot":
-		cli := util.NewOrderedMap()
-		cli.Set("type", "local")
-		cli.Set("command", spawn.Command)
-		cli.Set("args", toAny(spawn.Args))
-		cli.Set("tools", []any{"*"})
-		ide := headroomStdioEntry(spawn)
-		foundCLI, matchesCLI := headroomJSONEntry(util.CopilotPathsResolved().McpConfig, "mcpServers", cli)
-		foundIDE, matchesIDE := headroomJSONEntry(filepath.Join(agents.IdeProjectRoot(), ".vscode", "mcp.json"), "servers", ide)
-		return foundCLI || foundIDE, foundCLI && matchesCLI && foundIDE && matchesIDE
-	case "droid":
-		entry := util.NewOrderedMap()
-		entry.Set("command", spawn.Command)
-		entry.Set("args", toAny(spawn.Args))
-		entry.Set("enabledTools", toAny(agents.HeadroomDroidToolNames))
-		return headroomJSONEntry(filepath.Join(util.Home(), ".factory", "mcp.json"), "mcpServers", entry)
-	case "grok":
-		return agents.GrokHeadroomMcpHas(), agents.GrokHeadroomMcpHas()
-	case "pi":
-		entry := util.NewOrderedMap()
-		entry.Set("command", spawn.Command)
-		entry.Set("args", toAny(spawn.Args))
-		entry.Set("lifecycle", "lazy")
-		entry.Set("directTools", true)
-		return headroomJSONEntry(filepath.Join(agents.PiAgentDirResolved(), "mcp.json"), "mcpServers", entry)
-	case "omp":
-		return agents.OmpMcpHas("headroom"), agents.OmpMcpHas("headroom")
-	case "kilo":
-		return agents.KiloMcpConfigured("headroom"), agents.KiloMcpMatches("headroom", command)
-	case "cline":
-		return agents.ClineMcpConfigured("headroom"), agents.ClineMcpMatches("headroom", command)
-	}
-	return false, false
-}
-
-func headroomStdioEntry(spawn util.McpSpawn) *util.OrderedMap {
-	entry := util.NewOrderedMap()
-	entry.Set("type", "stdio")
-	entry.Set("command", spawn.Command)
-	entry.Set("args", toAny(spawn.Args))
-	return entry
-}
-
-func headroomJSONEntries(paths []string, key string, expected *util.OrderedMap) (found, matches bool) {
-	matches = true
-	for _, path := range paths {
-		seen, same := headroomJSONEntry(path, key, expected)
-		if seen {
-			found = true
-			matches = matches && same
-		}
-	}
-	return found, matches
-}
-
-func headroomJSONEntry(path, key string, expected *util.OrderedMap) (found, matches bool) {
-	raw, ok := util.ReadFileSafe(path)
-	if !ok {
-		return false, false
-	}
-	cfg := util.TryParseJsonc(raw)
-	if cfg == nil {
-		return false, false
-	}
-	v, ok := cfg.Get(key)
-	if !ok {
-		return false, false
-	}
-	m, ok := v.(*util.OrderedMap)
-	if !ok {
-		return false, false
-	}
-	entry, found := m.Get("headroom")
-	return found, found && util.StringifyJSON(entry) == util.StringifyJSON(expected)
+	return headroompkg.McpMatches(agent) && HasOwner(agent, "headroom")
 }
 
 var headroom = &core.ToolManifest{
 	ID: "headroom", Label: "Headroom", Description: "On-demand MCP compression for large, self-contained text.",
 	Homepage: "https://github.com/headroomlabs-ai/headroom", InstallHint: "Tokless-managed uv tool: headroom-ai[mcp] (Python 3.13).",
-	Channel: core.ChannelBinary, NotTrackable: true, Install: headroomEnsureInstalled,
+	Channel: core.ChannelBinary, NotTrackable: true, Install: headroompkg.EnsureInstalled,
 	WireFor: map[string]core.AgentFn{}, UnwireFor: map[string]core.AgentFn{}, VerifyFor: map[string]core.VerifyFn{},
 }
 

--- a/internal/tools/headroom_test.go
+++ b/internal/tools/headroom_test.go
@@ -1,10 +1,6 @@
 package tools
 
 import (
-	"context"
-	"os"
-	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -18,144 +14,25 @@ func setupHeadroomHome(t *testing.T) string {
 	home := t.TempDir()
 	util.SetHomeOverride(home)
 	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
 	t.Setenv("TOKLESS_TEST", "1")
 	agents.SetIdeProjectRoot(home)
 	ConfigureInstructionConflicts(true)
-	t.Cleanup(func() {
-		util.SetHomeOverride("")
-		agents.SetIdeProjectRoot("")
-		ConfigureInstructionConflicts(false)
-	})
+	t.Cleanup(func() { util.SetHomeOverride(""); agents.SetIdeProjectRoot(""); ConfigureInstructionConflicts(false) })
 	return home
 }
 
-func TestHeadroomInstallArgsAndNativeRisk(t *testing.T) {
-	if got, want := headroomPythonInstallArgs(), []string{"python", "install", "3.13"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("Python install args = %v, want %v", got, want)
-	}
-	if got, want := headroomInstallArgs(false), []string{"tool", "install", "--python", "3.13", "headroom-ai[mcp]"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("install args = %v, want %v", got, want)
-	}
-	if got, want := headroomInstallArgs(true), []string{"tool", "install", "--upgrade", "--python", "3.13", "headroom-ai[mcp]"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("upgrade args = %v, want %v", got, want)
-	}
-	if !headroomNativeBuildRiskFor("windows", "amd64") || !headroomNativeBuildRiskFor("darwin", "amd64") || headroomNativeBuildRiskFor("darwin", "arm64") || headroomNativeBuildRiskFor("linux", "amd64") {
-		t.Fatal("native build risk classification is incorrect")
-	}
-}
-
-func TestHeadroomInstallUsesManagedUVState(t *testing.T) {
-	home := t.TempDir()
-	util.SetHomeOverride(home)
-	t.Setenv("TOKLESS_TEST", "")
-	t.Cleanup(func() { util.SetHomeOverride("") })
-	p := util.HeadroomPathsResolved()
-	if err := os.MkdirAll(filepath.Dir(p.UV), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(p.UV, []byte("managed uv"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	old := runHeadroom
-	t.Cleanup(func() { runHeadroom = old })
-	var calls [][]string
-	runHeadroom = func(command string, args, env []string, ctx context.Context) util.ExecResult {
-		calls = append(calls, append([]string{command}, args...))
-		if command == util.HeadroomBin() {
-			<-ctx.Done()
-			return util.ExecResult{Code: 1}
+func TestHeadroomMapsEveryRegisteredAgent(t *testing.T) {
+	for _, agent := range core.AgentIDs() {
+		if _, ok := headroom.WireFor[agent]; !ok {
+			t.Errorf("missing WireFor mapping for registered agent %q", agent)
 		}
-		if command != p.UV {
-			return util.ExecResult{Code: 1, Stderr: "unexpected uv"}
+		if _, ok := headroom.UnwireFor[agent]; !ok {
+			t.Errorf("missing UnwireFor mapping for registered agent %q", agent)
 		}
-		for _, item := range util.HeadroomEnv() {
-			if !containsString(env, item) {
-				return util.ExecResult{Code: 1, Stderr: "missing managed env"}
-			}
+		if _, ok := headroom.VerifyFor[agent]; !ok {
+			t.Errorf("missing VerifyFor mapping for registered agent %q", agent)
 		}
-		if reflect.DeepEqual(args, headroomInstallArgs(false)) || reflect.DeepEqual(args, headroomInstallArgs(true)) {
-			if err := os.MkdirAll(filepath.Dir(util.HeadroomBin()), 0o755); err != nil {
-				return util.ExecResult{Code: 1, Stderr: err.Error()}
-			}
-			if err := os.WriteFile(util.HeadroomBin(), []byte("headroom"), 0o755); err != nil {
-				return util.ExecResult{Code: 1, Stderr: err.Error()}
-			}
-		}
-		return util.ExecResult{}
-	}
-	if ok, err := headroomEnsureInstalled(core.RunOpts{}); err != nil || !ok {
-		t.Fatalf("install = %v, %v", ok, err)
-	}
-	if len(calls) != 4 || !reflect.DeepEqual(calls[0], []string{p.UV, "--version"}) || !reflect.DeepEqual(calls[1], append([]string{p.UV}, headroomPythonInstallArgs()...)) || !reflect.DeepEqual(calls[2], append([]string{p.UV}, headroomInstallArgs(false)...)) {
-		t.Fatalf("install call = %v", calls)
-	}
-	if ok, err := headroomEnsureInstalled(core.RunOpts{Upgrade: true}); err != nil || !ok {
-		t.Fatalf("upgrade = %v, %v", ok, err)
-	}
-	if len(calls) != 8 || !reflect.DeepEqual(calls[6], append([]string{p.UV}, headroomInstallArgs(true)...)) {
-		t.Fatalf("upgrade calls = %v", calls)
-	}
-}
-
-func TestHeadroomServeProbeRequiresLiveServer(t *testing.T) {
-	old := runHeadroom
-	t.Cleanup(func() { runHeadroom = old })
-	runHeadroom = func(string, []string, []string, context.Context) util.ExecResult {
-		return util.ExecResult{Code: 127, Stderr: "bad entry point"}
-	}
-	if err := headroomServeProbe(); err == nil || !strings.Contains(err.Error(), "executable verification") {
-		t.Fatalf("immediate failure = %v", err)
-	}
-	runHeadroom = func(_ string, _ []string, _ []string, ctx context.Context) util.ExecResult {
-		<-ctx.Done()
-		return util.ExecResult{Code: 1}
-	}
-	if err := headroomServeProbe(); err != nil {
-		t.Fatalf("live server probe = %v", err)
-	}
-}
-
-func TestHeadroomFailedUpgradeKeepsManagedExecutable(t *testing.T) {
-	home := t.TempDir()
-	util.SetHomeOverride(home)
-	t.Setenv("TOKLESS_TEST", "")
-	t.Cleanup(func() { util.SetHomeOverride("") })
-	p := util.HeadroomPathsResolved()
-	if err := os.MkdirAll(filepath.Dir(p.UV), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(p.UV, []byte("managed uv"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(util.HeadroomBin()), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(util.HeadroomBin(), []byte("working"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	old := runHeadroom
-	t.Cleanup(func() { runHeadroom = old })
-	runHeadroom = func(_ string, args, _ []string, _ context.Context) util.ExecResult {
-		if reflect.DeepEqual(args, []string{"--version"}) {
-			return util.ExecResult{}
-		}
-		return util.ExecResult{Code: 1, Stderr: "build failed"}
-	}
-	if ok, err := headroomEnsureInstalled(core.RunOpts{Upgrade: true}); err == nil || ok || !strings.Contains(err.Error(), "managed Python") {
-		t.Fatalf("failed upgrade = %v, %v", ok, err)
-	}
-	if got, err := os.ReadFile(util.HeadroomBin()); err != nil || string(got) != "working" {
-		t.Fatalf("existing executable changed: %q, %v", got, err)
-	}
-}
-
-func TestHeadroomFailureExplainsNativeBuildRisk(t *testing.T) {
-	if !strings.Contains(headroomFailure("package install", util.ExecResult{Stderr: "build failed"}).Error(), "build failed") {
-		t.Fatal("failure omitted process detail")
-	}
-	if !headroomNativeBuildRiskFor("windows", "amd64") {
-		t.Fatal("expected native build warning platform")
 	}
 }
 
@@ -212,13 +89,4 @@ func TestHeadroomVerifierRejectsUnboundedServer(t *testing.T) {
 	if !strings.Contains(raw, `"command":"headroom"`) {
 		t.Fatalf("unwire removed user server: %s", raw)
 	}
-}
-
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/tools/headroom_test.go
+++ b/internal/tools/headroom_test.go
@@ -1,0 +1,224 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/HoangP8/tokless/internal/agents"
+	"github.com/HoangP8/tokless/internal/core"
+	"github.com/HoangP8/tokless/internal/util"
+)
+
+func setupHeadroomHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("TOKLESS_TEST", "1")
+	agents.SetIdeProjectRoot(home)
+	ConfigureInstructionConflicts(true)
+	t.Cleanup(func() {
+		util.SetHomeOverride("")
+		agents.SetIdeProjectRoot("")
+		ConfigureInstructionConflicts(false)
+	})
+	return home
+}
+
+func TestHeadroomInstallArgsAndNativeRisk(t *testing.T) {
+	if got, want := headroomPythonInstallArgs(), []string{"python", "install", "3.13"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Python install args = %v, want %v", got, want)
+	}
+	if got, want := headroomInstallArgs(false), []string{"tool", "install", "--python", "3.13", "headroom-ai[mcp]"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("install args = %v, want %v", got, want)
+	}
+	if got, want := headroomInstallArgs(true), []string{"tool", "install", "--upgrade", "--python", "3.13", "headroom-ai[mcp]"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("upgrade args = %v, want %v", got, want)
+	}
+	if !headroomNativeBuildRiskFor("windows", "amd64") || !headroomNativeBuildRiskFor("darwin", "amd64") || headroomNativeBuildRiskFor("darwin", "arm64") || headroomNativeBuildRiskFor("linux", "amd64") {
+		t.Fatal("native build risk classification is incorrect")
+	}
+}
+
+func TestHeadroomInstallUsesManagedUVState(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("TOKLESS_TEST", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	p := util.HeadroomPathsResolved()
+	if err := os.MkdirAll(filepath.Dir(p.UV), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.UV, []byte("managed uv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := runHeadroom
+	t.Cleanup(func() { runHeadroom = old })
+	var calls [][]string
+	runHeadroom = func(command string, args, env []string, ctx context.Context) util.ExecResult {
+		calls = append(calls, append([]string{command}, args...))
+		if command == util.HeadroomBin() {
+			<-ctx.Done()
+			return util.ExecResult{Code: 1}
+		}
+		if command != p.UV {
+			return util.ExecResult{Code: 1, Stderr: "unexpected uv"}
+		}
+		for _, item := range util.HeadroomEnv() {
+			if !containsString(env, item) {
+				return util.ExecResult{Code: 1, Stderr: "missing managed env"}
+			}
+		}
+		if reflect.DeepEqual(args, headroomInstallArgs(false)) || reflect.DeepEqual(args, headroomInstallArgs(true)) {
+			if err := os.MkdirAll(filepath.Dir(util.HeadroomBin()), 0o755); err != nil {
+				return util.ExecResult{Code: 1, Stderr: err.Error()}
+			}
+			if err := os.WriteFile(util.HeadroomBin(), []byte("headroom"), 0o755); err != nil {
+				return util.ExecResult{Code: 1, Stderr: err.Error()}
+			}
+		}
+		return util.ExecResult{}
+	}
+	if ok, err := headroomEnsureInstalled(core.RunOpts{}); err != nil || !ok {
+		t.Fatalf("install = %v, %v", ok, err)
+	}
+	if len(calls) != 4 || !reflect.DeepEqual(calls[0], []string{p.UV, "--version"}) || !reflect.DeepEqual(calls[1], append([]string{p.UV}, headroomPythonInstallArgs()...)) || !reflect.DeepEqual(calls[2], append([]string{p.UV}, headroomInstallArgs(false)...)) {
+		t.Fatalf("install call = %v", calls)
+	}
+	if ok, err := headroomEnsureInstalled(core.RunOpts{Upgrade: true}); err != nil || !ok {
+		t.Fatalf("upgrade = %v, %v", ok, err)
+	}
+	if len(calls) != 8 || !reflect.DeepEqual(calls[6], append([]string{p.UV}, headroomInstallArgs(true)...)) {
+		t.Fatalf("upgrade calls = %v", calls)
+	}
+}
+
+func TestHeadroomServeProbeRequiresLiveServer(t *testing.T) {
+	old := runHeadroom
+	t.Cleanup(func() { runHeadroom = old })
+	runHeadroom = func(string, []string, []string, context.Context) util.ExecResult {
+		return util.ExecResult{Code: 127, Stderr: "bad entry point"}
+	}
+	if err := headroomServeProbe(); err == nil || !strings.Contains(err.Error(), "executable verification") {
+		t.Fatalf("immediate failure = %v", err)
+	}
+	runHeadroom = func(_ string, _ []string, _ []string, ctx context.Context) util.ExecResult {
+		<-ctx.Done()
+		return util.ExecResult{Code: 1}
+	}
+	if err := headroomServeProbe(); err != nil {
+		t.Fatalf("live server probe = %v", err)
+	}
+}
+
+func TestHeadroomFailedUpgradeKeepsManagedExecutable(t *testing.T) {
+	home := t.TempDir()
+	util.SetHomeOverride(home)
+	t.Setenv("TOKLESS_TEST", "")
+	t.Cleanup(func() { util.SetHomeOverride("") })
+	p := util.HeadroomPathsResolved()
+	if err := os.MkdirAll(filepath.Dir(p.UV), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.UV, []byte("managed uv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(util.HeadroomBin()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(util.HeadroomBin(), []byte("working"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := runHeadroom
+	t.Cleanup(func() { runHeadroom = old })
+	runHeadroom = func(_ string, args, _ []string, _ context.Context) util.ExecResult {
+		if reflect.DeepEqual(args, []string{"--version"}) {
+			return util.ExecResult{}
+		}
+		return util.ExecResult{Code: 1, Stderr: "build failed"}
+	}
+	if ok, err := headroomEnsureInstalled(core.RunOpts{Upgrade: true}); err == nil || ok || !strings.Contains(err.Error(), "managed Python") {
+		t.Fatalf("failed upgrade = %v, %v", ok, err)
+	}
+	if got, err := os.ReadFile(util.HeadroomBin()); err != nil || string(got) != "working" {
+		t.Fatalf("existing executable changed: %q, %v", got, err)
+	}
+}
+
+func TestHeadroomFailureExplainsNativeBuildRisk(t *testing.T) {
+	if !strings.Contains(headroomFailure("package install", util.ExecResult{Stderr: "build failed"}).Error(), "build failed") {
+		t.Fatal("failure omitted process detail")
+	}
+	if !headroomNativeBuildRiskFor("windows", "amd64") {
+		t.Fatal("expected native build warning platform")
+	}
+}
+
+func TestHeadroomWiresEverySupportedAgentIdempotently(t *testing.T) {
+	setupHeadroomHome(t)
+	for _, agent := range []string{"claude", "opencode", "codex", "cursor", "antigravity", "copilot", "droid", "grok", "pi", "omp", "kilo", "cline"} {
+		t.Run(agent, func(t *testing.T) {
+			for i := 0; i < 2; i++ {
+				ok, err := headroom.WireFor[agent](core.RunOpts{})
+				if err != nil || !ok || !headroomVerify(agent) {
+					t.Fatalf("wire %d = %v, %v; verify=%v", i+1, ok, err, headroomVerify(agent))
+				}
+			}
+			ok, err := headroom.UnwireFor[agent](core.RunOpts{})
+			if err != nil || !ok || headroomVerify(agent) {
+				t.Fatalf("unwire = %v, %v; verify=%v", ok, err, headroomVerify(agent))
+			}
+		})
+	}
+}
+
+func TestHeadroomRefusesDirectUserServer(t *testing.T) {
+	setupHeadroomHome(t)
+	p := util.ClaudeCodePaths()
+	if err := util.WriteFile(p.GlobalJSON, `{"mcpServers":{"headroom":{"type":"stdio","command":"headroom","args":["mcp","serve"]}}}`); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := headroom.WireFor["claude"](core.RunOpts{})
+	if err == nil || ok || !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Fatalf("wire direct user server = %v, %v", ok, err)
+	}
+	raw, _ := util.ReadFileSafe(p.GlobalJSON)
+	if !strings.Contains(raw, `"command":"headroom"`) || HasOwner("claude", "headroom") {
+		t.Fatalf("user server changed or ownership claimed: %s", raw)
+	}
+}
+
+func TestHeadroomVerifierRejectsUnboundedServer(t *testing.T) {
+	setupHeadroomHome(t)
+	if ok, err := headroom.WireFor["claude"](core.RunOpts{}); err != nil || !ok {
+		t.Fatalf("wire = %v, %v", ok, err)
+	}
+	p := util.ClaudeCodePaths()
+	if err := util.WriteFile(p.GlobalJSON, `{"mcpServers":{"headroom":{"type":"stdio","command":"headroom","args":["mcp","serve"]}}}`); err != nil {
+		t.Fatal(err)
+	}
+	if headroomVerify("claude") {
+		t.Fatal("direct headroom server must not verify as Tokless-managed")
+	}
+	if ok, err := headroom.UnwireFor["claude"](core.RunOpts{}); err != nil || ok {
+		t.Fatalf("unwire unbounded server = %v, %v", ok, err)
+	}
+	raw, _ := util.ReadFileSafe(p.GlobalJSON)
+	if !strings.Contains(raw, `"command":"headroom"`) {
+		t.Fatalf("unwire removed user server: %s", raw)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/kilo_test.go
+++ b/internal/tools/kilo_test.go
@@ -127,6 +127,7 @@ func TestKiloContextAndCodegraphWireVerify(t *testing.T) {
 func TestKiloContextVerifyRejectsMutatedValidEntry(t *testing.T) {
 	kiloToolProject(t)
 	t.Setenv("TOKLESS_TEST", "1")
+	t.Setenv("KILO_CONFIG_DIR", filepath.Join(t.TempDir(), "global"))
 	binDir := t.TempDir()
 	kiloExecutableFixture(t, binDir, "rtk", "rtk")
 	t.Setenv("PATH", binDir)

--- a/internal/util/headroom.go
+++ b/internal/util/headroom.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// HeadroomPaths contains only directories owned by Tokless.
+type HeadroomPaths struct {
+	Root   string
+	UV     string
+	Tools  string
+	Bin    string
+	Python string
+}
+
+func HeadroomPathsResolved() HeadroomPaths {
+	root := filepath.Join(ToklessDataDir(), "headroom")
+	bin := filepath.Join(root, "bin")
+	uv := filepath.Join(root, "uv", "uv")
+	if IsWin {
+		uv += ".exe"
+	}
+	return HeadroomPaths{Root: root, UV: uv, Tools: filepath.Join(root, "tools"), Bin: bin, Python: filepath.Join(root, "python")}
+}
+
+func HeadroomBin() string {
+	p := filepath.Join(HeadroomPathsResolved().Bin, "headroom")
+	if IsWin {
+		return p + ".exe"
+	}
+	return p
+}
+
+func HeadroomEnv() []string {
+	p := HeadroomPathsResolved()
+	return []string{
+		"UV_TOOL_DIR=" + p.Tools,
+		"UV_TOOL_BIN_DIR=" + p.Bin,
+		"UV_PYTHON_INSTALL_DIR=" + p.Python,
+		"UV_MANAGED_PYTHON=1",
+	}
+}
+
+func HeadroomUVBootstrapEnv() []string {
+	p := HeadroomPathsResolved()
+	return append(HeadroomEnv(), "UV_INSTALL_DIR="+filepath.Dir(p.UV), "UV_NO_MODIFY_PATH=1")
+}
+
+func McpSpawnFor(toolID string) McpSpawn {
+	if toolID == "headroom" {
+		return WrapBoundedTool("headroom", McpSpawn{Command: HeadroomBin(), Args: []string{"mcp", "serve"}})
+	}
+	return PickMcpSpawn(toolID)
+}
+
+func HeadroomInstalled() bool {
+	info, err := os.Stat(HeadroomBin())
+	return err == nil && !info.IsDir()
+}

--- a/internal/util/headroom_proxy.go
+++ b/internal/util/headroom_proxy.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+const headroomProxyDefaultPort = 8787
+
+// HeadroomProxyPort returns the headroom daemon port: TOKLESS_HEADROOM_PROXY_PORT.
+func HeadroomProxyPort() int {
+	if raw := strings.TrimSpace(os.Getenv("TOKLESS_HEADROOM_PROXY_PORT")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= 65535 {
+			return n
+		}
+	}
+	return headroomProxyDefaultPort
+}
+
+// HeadroomProxyURL is the local daemon base URL.
+func HeadroomProxyURL() string {
+	return "http://127.0.0.1:" + strconv.Itoa(HeadroomProxyPort())
+}
+
+// HeadroomProxyOpenAIURL is the daemon's OpenAI-compatible base URL.
+func HeadroomProxyOpenAIURL() string {
+	return HeadroomProxyURL() + "/v1"
+}

--- a/internal/util/headroom_test.go
+++ b/internal/util/headroom_test.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestHeadroomPathsEnvAndSpawnAreToklessOwned(t *testing.T) {
+	home := t.TempDir()
+	SetHomeOverride(home)
+	t.Cleanup(func() { SetHomeOverride("") })
+	p := HeadroomPathsResolved()
+	root := filepath.Join(home, ".local", "share", "tokless", "headroom")
+	for _, path := range []string{p.Root, p.UV, p.Tools, p.Bin, p.Python, HeadroomBin()} {
+		if !strings.HasPrefix(path, root) {
+			t.Fatalf("path outside Tokless root: %q", path)
+		}
+	}
+	for _, env := range HeadroomEnv() {
+		if !strings.Contains(env, root) && env != "UV_MANAGED_PYTHON=1" {
+			t.Fatalf("environment outside Tokless root: %q", env)
+		}
+	}
+	spawn := McpSpawnFor("headroom")
+	want := []string{"run-mcp", "--tool", "headroom", HeadroomBin(), "mcp", "serve"}
+	if spawn.Command == HeadroomBin() || !reflect.DeepEqual(spawn.Args, want) {
+		t.Fatalf("spawn = %q %v, want wrapped %v", spawn.Command, spawn.Args, want)
+	}
+}

--- a/internal/util/instructions.go
+++ b/internal/util/instructions.go
@@ -15,6 +15,7 @@ var ToklessOwners = []string{
 	"ponytail",
 	"codegraph",
 	"context-mode",
+	"headroom",
 }
 
 // SectionsByOwner maps each owner to its heading marker.
@@ -24,6 +25,7 @@ var SectionsByOwner = map[string]string{
 	"ponytail":     "## Build Discipline (ponytail)",
 	"codegraph":    "## Code Index (codegraph)",
 	"context-mode": "## Context Tools (context-mode)",
+	"headroom":     "## Headroom (headroom)",
 }
 
 // CursorProjectRuleSpec describes one checked-in Cursor project rule.
@@ -172,6 +174,10 @@ func ToklessAgentBody(owners []string) string {
 	}
 	if hasOwner(owners, "context-mode") {
 		b.WriteString(instructionSection("context-mode"))
+		b.WriteString("\n\n")
+	}
+	if hasOwner(owners, "headroom") {
+		b.WriteString(instructionSection("headroom"))
 		b.WriteString("\n\n")
 	}
 	return strings.TrimRight(b.String(), "\n")

--- a/internal/util/jsonc.go
+++ b/internal/util/jsonc.go
@@ -203,6 +203,32 @@ func TryParseJsonc(text string) *OrderedMap {
 	return m
 }
 
+// HasJSONCComments reports comment markers outside JSON strings.
+func HasJSONCComments(raw string) bool {
+	inString, escaped := false, false
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if inString {
+			if escaped {
+				escaped = false
+			} else if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			continue
+		}
+		if c == '/' && i+1 < len(raw) && (raw[i+1] == '/' || raw[i+1] == '*') {
+			return true
+		}
+	}
+	return false
+}
+
 // StringifyJSON matches JSON.stringify(obj, null, 2) + "\n".
 func StringifyJSON(v any) string {
 	var buf bytes.Buffer

--- a/internal/util/jsonc_test.go
+++ b/internal/util/jsonc_test.go
@@ -128,3 +128,12 @@ func TestTryParseJsoncBadInput(t *testing.T) {
 		t.Errorf("expected nil for bad json, got: %v", got)
 	}
 }
+
+func TestHasJSONCComments(t *testing.T) {
+	if HasJSONCComments(`{"url":"https://example.test/a//b", "x":"/* not comment */"}`) {
+		t.Fatal("string markers must not count as comments")
+	}
+	if !HasJSONCComments("{\"url\":\"https://example.test/a\" // comment\n}") {
+		t.Fatal("expected comment marker outside string")
+	}
+}

--- a/internal/util/mcpspawn.go
+++ b/internal/util/mcpspawn.go
@@ -275,3 +275,10 @@ func WrapContextMode(s McpSpawn) McpSpawn {
 	args = append(args, s.Args...)
 	return McpSpawn{Command: self, Args: args}
 }
+
+// WrapBoundedTool routes an MCP server through Tokless's allowlist proxy.
+func WrapBoundedTool(toolID string, s McpSpawn) McpSpawn {
+	self := toklessRunMcpCommand()
+	args := append([]string{"run-mcp", "--tool", toolID, s.Command}, s.Args...)
+	return McpSpawn{Command: self, Args: args}
+}

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -113,11 +113,30 @@ func ReadFileSafe(p string) (string, bool) {
 	return string(b), true
 }
 
+var writeFileOverride func(string, string) error
+
+// SetWriteFileOverride installs a narrow persistence seam for tests.
+func SetWriteFileOverride(fn func(string, string) error) { writeFileOverride = fn }
+
 func WriteFile(p, content string) error {
+	if writeFileOverride != nil {
+		return writeFileOverride(p, content)
+	}
 	if err := EnsureDir(filepath.Dir(p)); err != nil {
 		return err
 	}
 	return os.WriteFile(p, []byte(content), 0o644)
+}
+
+// WriteFileMode writes content, using mode for new files.
+func WriteFileMode(p, content string, mode os.FileMode) error {
+	if writeFileOverride != nil {
+		return writeFileOverride(p, content)
+	}
+	if err := EnsureDir(filepath.Dir(p)); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(content), mode)
 }
 
 func Exists(p string) bool {

--- a/internal/util/paths_write_test.go
+++ b/internal/util/paths_write_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileModePreservesExistingPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFileMode(path, "new", 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("permissions changed: got %o, want 600", got)
+	}
+}
+
+func TestWriteFileModeUsesRequestedModeForNewFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	if err := WriteFileMode(path, "new", 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("permissions incorrect: got %o, want 600", got)
+	}
+}
+
+func TestWriteFileFollowsRegularFileSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "config")
+	if err := os.WriteFile(target, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(link, "new"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != "new" {
+		t.Fatalf("target = %q, err = %v; want new", got, err)
+	}
+}

--- a/internal/util/versions.go
+++ b/internal/util/versions.go
@@ -244,6 +244,7 @@ func gatherVersions(force bool) map[string]VersionInfo {
 			"rtk":          {Installed: strp("0.43.0"), Latest: strp("0.43.0"), Channel: "github", Present: false},
 			"codegraph":    {Installed: nil, Latest: strp("1.1.6"), Channel: "npm", Present: false},
 			"context-mode": {Installed: nil, Latest: strp("1.0.169"), Channel: "npm", Present: false},
+			"headroom":     {Channel: "uv", Present: HeadroomInstalled()},
 			"tokless":      {Installed: strp("0.1.0"), Latest: strp("0.1.0"), Channel: "npm", Present: false},
 		}
 	}
@@ -253,6 +254,7 @@ func gatherVersions(force bool) map[string]VersionInfo {
 	out["rtk"] = VersionInfo{Installed: rtkInstalledVersion(), Latest: latest["rtk"], Channel: "github", Present: rtkInstalledVersion() != nil}
 	out["codegraph"] = VersionInfo{Installed: npmInstalledVersion("@colbymchenry/codegraph"), Latest: latest["codegraph"], Channel: "npm", Present: npmInstalledVersion("@colbymchenry/codegraph") != nil}
 	out["context-mode"] = VersionInfo{Installed: npmInstalledVersion("context-mode"), Latest: latest["context-mode"], Channel: "npm", Present: npmInstalledVersion("context-mode") != nil}
+	out["headroom"] = VersionInfo{Channel: "uv", Present: HeadroomInstalled()}
 	out["tokless"] = VersionInfo{Installed: npmInstalledVersion("tokless"), Latest: latest["tokless"], Channel: "npm", Present: npmInstalledVersion("tokless") != nil}
 	return out
 }
@@ -313,7 +315,6 @@ func npmPkgDir(pkg string) string {
 	}
 	return ""
 }
-
 
 var toolIDs = []string{"rtk", "codegraph", "context-mode", "tokless"}
 
@@ -459,4 +460,3 @@ func CountOutdated(m map[string]VersionInfo) int {
 func BustVersionCache() {
 	_ = os.Remove(cachePath())
 }
-

--- a/internal/util/versions_headroom_test.go
+++ b/internal/util/versions_headroom_test.go
@@ -1,0 +1,14 @@
+package util
+
+import "testing"
+
+func TestGatherVersionsReportsHeadroomPresence(t *testing.T) {
+	home := t.TempDir()
+	SetHomeOverride(home)
+	t.Setenv("TOKLESS_TEST", "1")
+	t.Cleanup(func() { SetHomeOverride("") })
+	info, ok := GatherVersions()["headroom"]
+	if !ok || info.Channel != "uv" || info.Present {
+		t.Fatalf("headroom version info = %#v, exists=%v", info, ok)
+	}
+}


### PR DESCRIPTION
# Headroom HTTP proxy — BYOK agent routing

Adds `tokless proxy up|down|status` on Linux: a small local HTTP proxy so BYOK agents (claude, codex, opencode, omp, kilo, pi, droid) can reach their cached headroom backend on a fixed `127.0.0.1` endpoint, with per-agent wiring and status.

Highlights:

- **Safe daemon ownership** — status/stop only ever operate on the proxy this machine actually owns, tracked via identity records persisted atomically.
- **No half-started daemons** — if startup fails partway, the child is killed and reaped, with no stray processes or stale pid file left behind.
- **Conservative read-only detection** — unreadable config is treated as *unreadable*, never as *absent*; ownership is never guessed from endpoints, model names, or credentials, and readable Codex/OMP configs report as `unknown` rather than leaking details.
- **Config safety** — refuses to mutate config files that contain stray comments (JSONC) instead of silently corrupting them.
- `proxy up --agent` without an agent now exits with an error (no silent "all agents" default).
- `mcp run` startup runs through the bounded proxy and gates denied responses.
- `disable` also purges the headroom root when nothing is wired, and surfaces purge errors instead of swallowing them.
- Refactor: managed MCP install moved into `internal/headroom`.

Verification: `go build`, `go vet`, full suite passes (829 tests, also under `-race`); no existing tests removed — 148 new tests cover the proxy, detection, and validation paths.

Please merge with a **merge commit** (not squash) so the contributor attribution is preserved.